### PR TITLE
Don't close search veileder dropdown on nullstill, move buttons

### DIFF
--- a/src/components/toolbar/Dropdown/DropdownButton.tsx
+++ b/src/components/toolbar/Dropdown/DropdownButton.tsx
@@ -7,20 +7,14 @@ interface DropdownButtonProps extends KnappBaseProps {
   text: string;
 }
 
-const ButtonFlexBoxWrapper = styled.div`
-  flex: 1 0;
-`;
-
 const DropdownButton = ((props: DropdownButtonProps) => {
-  return (<ButtonFlexBoxWrapper>
-    <KnappBase
+  return (<KnappBase
       className={`confirmVeilederButton__${props.classNameElement}`}
       type={props.type}
       onClick={props.onClick}
       mini>
       {props.text}
-    </KnappBase>
-  </ButtonFlexBoxWrapper>);
+    </KnappBase>);
 });
 
 export default DropdownButton;

--- a/src/components/toolbar/Dropdown/DropdownButtons.tsx
+++ b/src/components/toolbar/Dropdown/DropdownButtons.tsx
@@ -19,9 +19,7 @@ const DropdownButtonsDiv = styled.div`
   margin: 2em .5em 1em .5em;
   display: flex;
   > :nth-child(2) {
-    > :nth-child(1) {
-      margin-left: -2em;
-    }
+    margin-left: .5em;
   }
 `;
 

--- a/src/components/toolbar/SearchVeileder/SearchVeileder.tsx
+++ b/src/components/toolbar/SearchVeileder/SearchVeileder.tsx
@@ -53,7 +53,6 @@ const SearchVeileder = (props: VeilederIdentsFilterProps) => {
         setActiveVeilederFilter([]);
         setActiveFilters(0);
         props.onSelect([]);
-        setShowList(false);
     };
 
     const inputChangeHandler = (event: ChangeEvent) => {


### PR DESCRIPTION
Fjern diven rundt knappene i dropdown, slik at avbryt-/nullstillknappene legger seg nærmere tildel-/lagreknappene.
Ikke sett showList i SearchVeileder til false når man nullstiller veiledersøket.