### PR TITLE
Remove name from call PersonInfo

### DIFF
--- a/src/store/personInfo/personInfoTypes.ts
+++ b/src/store/personInfo/personInfoTypes.ts
@@ -4,7 +4,6 @@ export interface Fodselsnummer {
 
 export interface PersonInfo {
   fnr: string;
-  navn: string;
   skjermingskode: string;
 }
 

--- a/src/store/personregister/personregisterReducer.ts
+++ b/src/store/personregister/personregisterReducer.ts
@@ -32,9 +32,6 @@ const personregisterReducer: Reducer<PersonregisterState> = (
       const personerSomSkalOppdateres: { [fnr: string]: PersonData } = navnHentet.map((personInfo: PersonInfo) => ({
         [personInfo.fnr]: {
           ...state[personInfo.fnr],
-          navn: hasName(state[personInfo.fnr])
-              ? state[personInfo.fnr].navn
-              : personInfo.navn,
           skjermingskode: personInfo.skjermingskode,
         },
       }));

--- a/test/data/fellesTestdata.ts
+++ b/test/data/fellesTestdata.ts
@@ -17,6 +17,7 @@ export const testdata = {
   navn1: 'Et navn',
   navn2: 'Et annet navn',
   navn3: 'Nok et navn..',
+  navn4: 'Nok et navn igjen',
   enhetId,
   veilederIdent,
   skjermingskode: {
@@ -47,6 +48,7 @@ export const personregister: PersonregisterState = {
 
 export const personoversikt = [
   {
+    navn: testdata.navn1,
     fnr: testdata.fnr1,
     enhet: enhetId,
     veilederIdent: null,
@@ -54,6 +56,7 @@ export const personoversikt = [
     oppfolgingstilfeller: [],
   } as PersonoversiktStatus,
   {
+    navn: testdata.navn4,
     fnr: testdata.fnr4,
     enhet: enhetId,
     veilederIdent,

--- a/test/store/personNavn/personInfoReducer.test.ts
+++ b/test/store/personNavn/personInfoReducer.test.ts
@@ -32,7 +32,6 @@ describe('personInfoReducer', () => {
     it(`handterer ${PersonInfoActionTypes.HENT_PERSON_INFO_HENTET}`, () => {
       const personInfoSvar = [{
         fnr: testdata.fnr1,
-        navn: testdata.navn1,
         skjermingskode: testdata.skjermingskode.ingen,
       }];
       const action = hentPersonInfoHentet(personInfoSvar);

--- a/test/store/personNavn/personInfoSagas.test.ts
+++ b/test/store/personNavn/personInfoSagas.test.ts
@@ -26,7 +26,6 @@ describe('hentPersonInfoSagas', () => {
   it(`Skal dernest sette ${PersonInfoActionTypes.HENT_PERSON_INFO_HENTET}`, () => {
     const personInfoSvar = [{
       fnr: testdata.fnr1,
-      navn: testdata.navn1,
       skjermingskode: testdata.skjermingskode.ingen,
     }];
     const nextPut = put({

--- a/test/store/personNavn/personInfo_actions.test.ts
+++ b/test/store/personNavn/personInfo_actions.test.ts
@@ -29,7 +29,6 @@ describe('personInfo_actions', () => {
   it('hentPersonInfoHentet() skal returnere riktig action', () => {
     const personInfoSvar = [ {
       fnr: testdata.fnr1,
-      navn: testdata.navn1,
       skjermingskode: testdata.skjermingskode.ingen,
     } ];
     expect(hentPersonInfoHentet(personInfoSvar)).to.deep.equal({

--- a/test/store/personregister/personregisterReducer.test.ts
+++ b/test/store/personregister/personregisterReducer.test.ts
@@ -43,11 +43,9 @@ describe('personregisterReducer', () => {
     it('handterer HENT_PERSON_INFO_HENTET', () => {
       const dataIForsteKall = [ {
         fnr: testdata.fnr1,
-        navn: testdata.navn1,
         skjermingskode: testdata.skjermingskode.ingen,
       }, {
         fnr: testdata.fnr2,
-        navn: testdata.navn2,
         skjermingskode: testdata.skjermingskode.ingen,
       } ];
       const dataIAndreKall = [ {
@@ -60,26 +58,21 @@ describe('personregisterReducer', () => {
       const forsteState = personregisterReducer(initialState, forsteAction);
       expect(forsteState).to.deep.equal({
         [testdata.fnr1]: {
-          navn: testdata.navn1,
           skjermingskode: testdata.skjermingskode.ingen,
         },
         [testdata.fnr2]: {
-          navn: testdata.navn2,
           skjermingskode: testdata.skjermingskode.ingen,
         },
       });
       const andreState = personregisterReducer(forsteState, andreAction);
       expect(andreState).to.deep.equal({
         [testdata.fnr1]: {
-          navn: testdata.navn1,
           skjermingskode: testdata.skjermingskode.ingen,
         },
         [testdata.fnr2]: {
-          navn: testdata.navn2,
           skjermingskode: testdata.skjermingskode.ingen,
         },
         [testdata.fnr3]: {
-          navn: testdata.navn3,
           skjermingskode: testdata.skjermingskode.ingen,
         },
       });
@@ -94,17 +87,14 @@ describe('personregisterReducer', () => {
       const dataIAndreKall = [
         {
           fnr: testdata.fnr1,
-          navn: testdata.navn1,
           skjermingskode: testdata.skjermingskode.ingen,
         },
         {
           fnr: testdata.fnr2,
-          navn: testdata.navn2,
           skjermingskode: testdata.skjermingskode.ingen,
         },
         {
           fnr: testdata.fnr4,
-          navn: testdata.navn3,
           skjermingskode: testdata.skjermingskode.ingen,
         } ];
       const hentPersonInfoAction = hentPersonInfoHentet(dataIAndreKall);
@@ -114,16 +104,14 @@ describe('personregisterReducer', () => {
         ...forsteState,
         [testdata.fnr1]: {
           ...forsteState[testdata.fnr1],
-          navn: testdata.navn1,
           skjermingskode: testdata.skjermingskode.ingen,
         },
         [testdata.fnr2]: {
-          navn: testdata.navn2,
+          ...forsteState[testdata.fnr2],
           skjermingskode: testdata.skjermingskode.ingen,
         },
         [testdata.fnr4]: {
           ...forsteState[testdata.fnr4],
-          navn: testdata.navn3,
           skjermingskode: testdata.skjermingskode.ingen,
         },
       };


### PR DESCRIPTION
Name is now supplied for all persons from PersonOversikt and hence is not needed from PersonInfo