### PR TITLE
Add HendelseTypeFilter ARBEIDSGIVER_BISTAND

### DIFF
--- a/Mock/Data/personoversiktEnhet.json
+++ b/Mock/Data/personoversiktEnhet.json
@@ -5,6 +5,7 @@
     "veilederIdent": null,
     "motebehovUbehandlet": null,
     "moteplanleggerUbehandlet": true,
+    "oppfolgingsplanLPSBistandUbehandlet": null,
     "oppfolgingstilfeller": []
   },
   {
@@ -13,6 +14,7 @@
     "veilederIdent": null,
     "motebehovUbehandlet": true,
     "moteplanleggerUbehandlet": null,
+    "oppfolgingsplanLPSBistandUbehandlet": null,
     "oppfolgingstilfeller": []
   },
   {
@@ -22,6 +24,7 @@
     "veilederIdent":"Z101010",
     "motebehovUbehandlet": true,
     "moteplanleggerUbehandlet": true,
+    "oppfolgingsplanLPSBistandUbehandlet": null,
     "oppfolgingstilfeller": []
   },
   {
@@ -31,6 +34,7 @@
     "veilederIdent":"Z101010",
     "motebehovUbehandlet": true,
     "moteplanleggerUbehandlet": true,
+    "oppfolgingsplanLPSBistandUbehandlet": null,
     "oppfolgingstilfeller": [
       {
         "virksomhetsnummer": "12345",
@@ -45,6 +49,7 @@
     "veilederIdent": null,
     "motebehovUbehandlet": true,
     "moteplanleggerUbehandlet": null,
+    "oppfolgingsplanLPSBistandUbehandlet": true,
     "oppfolgingstilfeller": [
       {
         "virksomhetsnummer": "12345",
@@ -59,6 +64,7 @@
     "veilederIdent": "Z202020",
     "motebehovUbehandlet": null,
     "moteplanleggerUbehandlet": true,
+    "oppfolgingsplanLPSBistandUbehandlet": null,
     "oppfolgingstilfeller": []
   },
   {
@@ -68,6 +74,7 @@
     "veilederIdent": null,
     "motebehovUbehandlet": true,
     "moteplanleggerUbehandlet": null,
+    "oppfolgingsplanLPSBistandUbehandlet": null,
     "oppfolgingstilfeller": []
   },
   {
@@ -77,6 +84,7 @@
     "veilederIdent": "Z202020",
     "motebehovUbehandlet": null,
     "moteplanleggerUbehandlet": true,
+    "oppfolgingsplanLPSBistandUbehandlet": null,
     "oppfolgingstilfeller": []
   },
   {
@@ -86,6 +94,7 @@
     "veilederIdent": "Z202020",
     "motebehovUbehandlet": null,
     "moteplanleggerUbehandlet": true,
+    "oppfolgingsplanLPSBistandUbehandlet": null,
     "oppfolgingstilfeller": []
   },
   {
@@ -95,6 +104,7 @@
     "veilederIdent": "Z202020",
     "motebehovUbehandlet": null,
     "moteplanleggerUbehandlet": true,
+    "oppfolgingsplanLPSBistandUbehandlet": null,
     "oppfolgingstilfeller": []
   },
   {
@@ -104,6 +114,7 @@
     "veilederIdent": "Z202020",
     "motebehovUbehandlet": null,
     "moteplanleggerUbehandlet": true,
+    "oppfolgingsplanLPSBistandUbehandlet": null,
     "oppfolgingstilfeller": []
   }
 ]

--- a/Mock/mockUtils.js
+++ b/Mock/mockUtils.js
@@ -43,6 +43,7 @@ const generatePersonoversiktEnhetFromPersons = (persons) => {
             veilederIdent: 'Z202020',
             motebehovUbehandlet: null,
             moteplanleggerUbehandlet: true,
+            oppfolgingsplanLPSBistandUbehandlet: null,
             oppfolgingstilfeller: []
         };
     })

--- a/src/components/HendelseTypeFilter.tsx
+++ b/src/components/HendelseTypeFilter.tsx
@@ -9,8 +9,10 @@ import { ApplicationState } from '../store';
 import { HendelseTypeFilters } from '../store/filters/filterReducer';
 import { updateHendelseFilterAction } from '../store/filters/filter_actions';
 import { OverviewTabType } from '../konstanter';
+import { toggleOppfolgingsplanLPSBistand } from '../toggle';
 
 export const HendelseTekster: any = {
+    ARBEIDSGIVER_BISTAND: 'Arbeidsgiver ønsker bistand',
     UFORDELTE_BRUKERE: 'Ufordelte brukere', // Ikke tildelt veileder
     MOTEBEHOV: 'Ønsker møte', // MØTEBEHOV - UBEHANDLET
     MOTEPLANLEGGER_SVAR: 'Svar møteplanlegger', // Svar fra møteplanlegger
@@ -23,6 +25,7 @@ interface Props extends ComponentPropsWithoutRef<any> {
 
 const enkeltFilterFraTekst = (tekst: string, checked: boolean): HendelseTypeFilters => {
     const filter: HendelseTypeFilters = {
+        arbeidsgiverOnskerMote: false,
         onskerMote: false,
         svartMote: false,
         ufordeltBruker: false,
@@ -32,6 +35,7 @@ const enkeltFilterFraTekst = (tekst: string, checked: boolean): HendelseTypeFilt
 
 const lagNyttFilter = (forrigeFilter: HendelseTypeFilters, tekst: string, checked: boolean): HendelseTypeFilters => {
     const filter = { ...forrigeFilter };
+    if (tekst === HendelseTekster.ARBEIDSGIVER_BISTAND) filter.arbeidsgiverOnskerMote = checked;
     if (tekst === HendelseTekster.MOTEBEHOV) filter.onskerMote = checked;
     if (tekst === HendelseTekster.MOTEPLANLEGGER_SVAR) filter.svartMote = checked;
     if (tekst === HendelseTekster.UFORDELTE_BRUKERE) filter.ufordeltBruker = checked;
@@ -39,6 +43,7 @@ const lagNyttFilter = (forrigeFilter: HendelseTypeFilters, tekst: string, checke
 };
 
 const isCheckedInState = (state: HendelseTypeFilters, tekst: string): boolean => {
+    if (tekst === HendelseTekster.ARBEIDSGIVER_BISTAND) return state.arbeidsgiverOnskerMote;
     if (tekst === HendelseTekster.MOTEBEHOV) return state.onskerMote;
     if (tekst === HendelseTekster.MOTEPLANLEGGER_SVAR) return state.svartMote;
     if (tekst === HendelseTekster.UFORDELTE_BRUKERE) return state.ufordeltBruker;
@@ -64,6 +69,8 @@ export default ({ className, personRegister, tabType }: Props) => {
     const elementer = Object.keys(HendelseTekster).filter((key) => {
         if (HendelseTekster[key] === HendelseTekster.UFORDELTE_BRUKERE && tabType === OverviewTabType.MY_OVERVIEW) {
             return false;
+        } else if (HendelseTekster[key] === HendelseTekster.ARBEIDSGIVER_BISTAND) {
+            return toggleOppfolgingsplanLPSBistand();
         }
         return true;
     }).map((key) => {

--- a/src/store/filters/filterReducer.ts
+++ b/src/store/filters/filterReducer.ts
@@ -11,12 +11,14 @@ export interface FilterState {
 }
 
 export interface HendelseTypeFilters {
+    arbeidsgiverOnskerMote: boolean;
     onskerMote: boolean;
     svartMote: boolean;
     ufordeltBruker: boolean;
 }
 
 const initialHendelseFilter: HendelseTypeFilters = {
+    arbeidsgiverOnskerMote: false,
     onskerMote: false,
     svartMote: false,
     ufordeltBruker: false,

--- a/src/store/personoversikt/personoversiktTypes.ts
+++ b/src/store/personoversikt/personoversiktTypes.ts
@@ -5,6 +5,7 @@ export interface PersonoversiktStatus {
   veilederIdent: string | null;
   motebehovUbehandlet: boolean | null;
   moteplanleggerUbehandlet: boolean | null;
+  oppfolgingsplanLPSBistandUbehandlet: boolean | null;
   oppfolgingstilfeller: Oppfolgingstilfelle[] | [];
 }
 

--- a/src/store/personregister/personregisterReducer.ts
+++ b/src/store/personregister/personregisterReducer.ts
@@ -60,6 +60,7 @@ const personregisterReducer: Reducer<PersonregisterState> = (
           tildeltVeilederIdent: person.veilederIdent,
           harMotebehovUbehandlet: person.motebehovUbehandlet,
           harMoteplanleggerUbehandlet: person.moteplanleggerUbehandlet,
+          harOppfolgingsplanLPSBistandUbehandlet: person.oppfolgingsplanLPSBistandUbehandlet,
           oppfolgingstilfeller: person.oppfolgingstilfeller,
         },
       }));

--- a/src/store/personregister/personregisterTypes.ts
+++ b/src/store/personregister/personregisterTypes.ts
@@ -6,6 +6,7 @@ export interface PersonData {
   navn: string;
   harMotebehovUbehandlet: boolean;
   harMoteplanleggerUbehandlet: boolean;
+  harOppfolgingsplanLPSBistandUbehandlet: boolean;
   skjermingskode: Skjermingskode;
   markert: boolean;
   tildeltEnhetId: string;

--- a/src/toggle.ts
+++ b/src/toggle.ts
@@ -1,0 +1,8 @@
+import {
+  erLokal,
+  erPreProd,
+} from './utils/miljoUtil';
+
+export const toggleOppfolgingsplanLPSBistand = () => {
+  return erLokal() || erPreProd();
+};

--- a/src/utils/hendelseFilteringUtils.tsx
+++ b/src/utils/hendelseFilteringUtils.tsx
@@ -98,6 +98,8 @@ export const filtrerPersonregister = (personregister: PersonregisterState, filte
             const personData = personregister[fnr];
             if (filter.onskerMote && personData.harMotebehovUbehandlet) {
                 cv[fnr] = personData;
+            } else if (filter.arbeidsgiverOnskerMote && personData.harOppfolgingsplanLPSBistandUbehandlet) {
+                cv[fnr] = personData;
             } else if (filter.svartMote && personData.harMoteplanleggerUbehandlet) {
                 cv[fnr] = personData;
             } else if (filter.ufordeltBruker && isNullOrUndefined(personData.tildeltVeilederIdent)) {

--- a/test/components/HendelseTypeFilter.test.tsx
+++ b/test/components/HendelseTypeFilter.test.tsx
@@ -3,7 +3,9 @@ import chaiEnzyme from 'chai-enzyme';
 import React from 'react';
 import { Checkbox } from 'nav-frontend-skjema';
 import { Provider } from 'react-redux';
-import SokeresultatFilter from '../../src/components/HendelseTypeFilter';
+import SokeresultatFilter, {
+    HendelseTekster,
+} from '../../src/components/HendelseTypeFilter';
 import { store } from '../../src/store';
 import { mount } from 'enzyme';
 
@@ -21,6 +23,7 @@ describe('SokeresultatFilter', () => {
         expect(component.contains(<Checkbox label={'Ønsker møte'} checked={false} />));
         expect(component.contains(<Checkbox label={'Svar møteplanlegger'} checked={false} />));
         expect(component.contains(<Checkbox label={'Ufordelte brukere'} checked={false} />));
+        expect(component.contains(<Checkbox label={HendelseTekster.ARBEIDSGIVER_BISTAND} checked={false} />));
     });
 
     // TODO: test click handling?


### PR DESCRIPTION
Show hendelseTypeFilter and number of persons with harOppfolgingsplanLPSBistandUbehandlet. This functionality is toggled on locally and i dev-fss, but is toggle off in prod-fss. The should be toggled on when the sending of Oppfolgingsplaner from LPS is turned on and events are generated by Ispersonoppgave.: