### PR TITLE
check for old news before displaying changelog

### DIFF
--- a/changelogs/1/tour.json
+++ b/changelogs/1/tour.json
@@ -1,6 +1,6 @@
 {
   "title": "Ny oppdatering",
-  "date": "10-09-19",
+  "date": "2019-09-10",
   "items": [
     {
       "title": "Tildel veileder",

--- a/changelogs/2/tour.json
+++ b/changelogs/2/tour.json
@@ -1,6 +1,6 @@
 {
   "title": "Ny oppdatering",
-  "date": "09-10-19",
+  "date": "2019-10-09",
   "items": [
     {
       "title": "Søk veileder",

--- a/changelogs/3/tour.json
+++ b/changelogs/3/tour.json
@@ -1,6 +1,6 @@
 {
   "title": "Velkommen!",
-  "date": "10-02-20",
+  "date": "2020-02-10",
   "items": [
     {
       "title": "Tildel veileder",

--- a/changelogs/4/tour.json
+++ b/changelogs/4/tour.json
@@ -1,6 +1,6 @@
 {
   "title": "Ny oppdatering",
-  "date": "30-09-20",
+  "date": "2020-09-30",
   "items": [
     {
       "title": "Ny hendelse",

--- a/src/components/changelog/ChangelogWrapper.tsx
+++ b/src/components/changelog/ChangelogWrapper.tsx
@@ -26,6 +26,15 @@ const saveChangelogVersionViewed = (version = 0) => {
   );
 };
 
+const isOldNews = (date: Date) => {
+  const MONTH_THRESHOLD = 2;
+  const today = new Date();
+
+  date.setMonth(date.getMonth() + MONTH_THRESHOLD);
+
+  return today > date;
+};
+
 export const ChangelogWrapper = (): ReactElement => {
   const changelogsQuery = useChangelogsQuery();
   const [showChangelog, setShowChangelog] = useState(false);
@@ -37,13 +46,15 @@ export const ChangelogWrapper = (): ReactElement => {
   )[0];
 
   useEffect(() => {
-    if (changelogsQuery.isSuccess) {
+    if (changelogsQuery.isSuccess && latestChangelog) {
       const storedSettings = getChangelogStorage();
-      setShowChangelog(
-        storedSettings && latestChangelog
-          ? storedSettings.viewed_version < latestChangelog.version
-          : true
-      );
+      if (!isOldNews(new Date(latestChangelog.date))) {
+        setShowChangelog(
+          storedSettings && latestChangelog
+            ? storedSettings.viewed_version < latestChangelog.version
+            : true
+        );
+      }
     }
   }, [changelogsQuery.isSuccess, latestChangelog]);
 


### PR DESCRIPTION
Rydda litt opp i datoene til changelog filene, da de ikke var på et særlig håndterlig format. Benytter nå ISO-standard: yyyy-mm-dd