### PR TITLE
Unngår oppdatering av notifications i context hvis notification finnes fra før

### DIFF
--- a/src/context/notification/NotificationContext.tsx
+++ b/src/context/notification/NotificationContext.tsx
@@ -27,10 +27,9 @@ export const NotificationProvider = ({
       value={{
         notifications,
         displayNotification: (notification) => {
-          const updatedNotifications = [
-            ...new Set([...notifications, notification]),
-          ];
-          setNotifications(updatedNotifications);
+          if (!notifications.includes(notification)) {
+            setNotifications([...notifications, notification]);
+          }
         },
         clearNotification: (type: NotificationType) => {
           setNotifications(notifications.filter((n) => n.type !== type));

--- a/test/components/Sokeresultat.test.tsx
+++ b/test/components/Sokeresultat.test.tsx
@@ -10,6 +10,7 @@ import Personliste from '../../src/components/Personliste';
 import { Filterable } from '@/utils/hendelseFilteringUtils';
 import { AktivEnhetProvider } from '@/context/aktivEnhet/AktivEnhetContext';
 import { NotificationProvider } from '@/context/notification/NotificationContext';
+import { stubAktivVeileder } from '../stubs/stubAktivVeileder';
 
 chai.use(chaiEnzyme());
 const expect = chai.expect;
@@ -20,6 +21,7 @@ const emptyBlock = () => {
 
 describe('Sokeresultat', () => {
   const queryClient = new QueryClient();
+  stubAktivVeileder();
 
   const component = mount(
     <NotificationProvider>


### PR DESCRIPTION
Når kall til endepunkt feiler blir `displayNotification` kjørt. Denne oppdaterte alltid `notifications` i `NotificationContext`, som igjen førte til at barn av context (f.eks. Oversikt) alltid ble re-rendret og kall til endepunkt ble kjørt på nytt. Dette førte til at kall som feilet ble kjørt på nytt i evig loop.