### PR TITLE
Simplify debugging of components using Styled-components

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -5,6 +5,7 @@
     "@babel/preset-typescript"
   ],
   "plugins": [
+    "babel-plugin-styled-components",
     "@babel/plugin-proposal-class-properties",
     "@babel/plugin-proposal-object-rest-spread",
     "@babel/plugin-transform-typescript",

--- a/package-lock.json
+++ b/package-lock.json
@@ -100,7 +100,7 @@
         "@sheerun/mutationobserver-shim": "0.3.3",
         "@testing-library/react": "12.1.4",
         "@testing-library/react-hooks": "7.0.2",
-        "@types/amplitude-js": "^8.16.0",
+        "@types/amplitude-js": "8.16.0",
         "@types/chai": "4.3.0",
         "@types/dotenv": "6.1.1",
         "@types/express": "4.17.13",
@@ -115,6 +115,7 @@
         "@typescript-eslint/parser": "5.18.0",
         "babel-loader": "8.2.4",
         "babel-plugin-module-resolver": "4.1.0",
+        "babel-plugin-styled-components": "^2.0.7",
         "chai": "4.3.6",
         "clean-webpack-plugin": "4.0.0",
         "css-loader": "5.2.7",
@@ -4621,14 +4622,15 @@
       }
     },
     "node_modules/babel-plugin-styled-components": {
-      "version": "1.12.0",
-      "resolved": "https://registry.npmjs.org/babel-plugin-styled-components/-/babel-plugin-styled-components-1.12.0.tgz",
-      "integrity": "sha512-FEiD7l5ZABdJPpLssKXjBUJMYqzbcNzBowfXDCdJhOpbhWiewapUaY+LZGT8R4Jg2TwOjGjG4RKeyrO5p9sBkA==",
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/babel-plugin-styled-components/-/babel-plugin-styled-components-2.0.7.tgz",
+      "integrity": "sha512-i7YhvPgVqRKfoQ66toiZ06jPNA3p6ierpfUuEWxNF+fV27Uv5gxBkf8KZLHUCc1nFA9j6+80pYoIpqCeyW3/bA==",
       "dependencies": {
-        "@babel/helper-annotate-as-pure": "^7.0.0",
-        "@babel/helper-module-imports": "^7.0.0",
+        "@babel/helper-annotate-as-pure": "^7.16.0",
+        "@babel/helper-module-imports": "^7.16.0",
         "babel-plugin-syntax-jsx": "^6.18.0",
-        "lodash": "^4.17.11"
+        "lodash": "^4.17.11",
+        "picomatch": "^2.3.0"
       },
       "peerDependencies": {
         "styled-components": ">= 2"
@@ -19936,14 +19938,15 @@
       }
     },
     "babel-plugin-styled-components": {
-      "version": "1.12.0",
-      "resolved": "https://registry.npmjs.org/babel-plugin-styled-components/-/babel-plugin-styled-components-1.12.0.tgz",
-      "integrity": "sha512-FEiD7l5ZABdJPpLssKXjBUJMYqzbcNzBowfXDCdJhOpbhWiewapUaY+LZGT8R4Jg2TwOjGjG4RKeyrO5p9sBkA==",
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/babel-plugin-styled-components/-/babel-plugin-styled-components-2.0.7.tgz",
+      "integrity": "sha512-i7YhvPgVqRKfoQ66toiZ06jPNA3p6ierpfUuEWxNF+fV27Uv5gxBkf8KZLHUCc1nFA9j6+80pYoIpqCeyW3/bA==",
       "requires": {
-        "@babel/helper-annotate-as-pure": "^7.0.0",
-        "@babel/helper-module-imports": "^7.0.0",
+        "@babel/helper-annotate-as-pure": "^7.16.0",
+        "@babel/helper-module-imports": "^7.16.0",
         "babel-plugin-syntax-jsx": "^6.18.0",
-        "lodash": "^4.17.11"
+        "lodash": "^4.17.11",
+        "picomatch": "^2.3.0"
       }
     },
     "babel-plugin-syntax-jsx": {

--- a/package.json
+++ b/package.json
@@ -127,6 +127,7 @@
     "@typescript-eslint/parser": "5.18.0",
     "babel-loader": "8.2.4",
     "babel-plugin-module-resolver": "4.1.0",
+    "babel-plugin-styled-components": "2.0.7",
     "chai": "4.3.6",
     "clean-webpack-plugin": "4.0.0",
     "css-loader": "5.2.7",


### PR DESCRIPTION
Add babel-plugin-styled-components to make is easier to debug html elements and css rendered from componennts using styled-components. This package adds automatic annoations of styled components with a unique and readable html class name.