### PR TITLE
Filter list of Persons based on status of Dialogmote and Kandidat

### DIFF
--- a/mock/data/personoversiktEnhet.json
+++ b/mock/data/personoversiktEnhet.json
@@ -5,7 +5,9 @@
     "veilederIdent": null,
     "motebehovUbehandlet": null,
     "moteplanleggerUbehandlet": true,
-    "oppfolgingsplanLPSBistandUbehandlet": null
+    "oppfolgingsplanLPSBistandUbehandlet": null,
+    "dialogmotekandidat": null,
+    "motestatus": null
   },
   {
     "fnr": "99999922222",
@@ -13,7 +15,9 @@
     "veilederIdent": null,
     "motebehovUbehandlet": true,
     "moteplanleggerUbehandlet": null,
-    "oppfolgingsplanLPSBistandUbehandlet": null
+    "oppfolgingsplanLPSBistandUbehandlet": null,
+    "dialogmotekandidat": null,
+    "motestatus": null
   },
   {
     "fnr": "99999933333",
@@ -22,7 +26,9 @@
     "veilederIdent": "Z101010",
     "motebehovUbehandlet": true,
     "moteplanleggerUbehandlet": true,
-    "oppfolgingsplanLPSBistandUbehandlet": null
+    "oppfolgingsplanLPSBistandUbehandlet": null,
+    "dialogmotekandidat": null,
+    "motestatus": null
   },
   {
     "fnr": "99999944444",
@@ -32,6 +38,8 @@
     "motebehovUbehandlet": true,
     "moteplanleggerUbehandlet": true,
     "oppfolgingsplanLPSBistandUbehandlet": null,
+    "dialogmotekandidat": null,
+    "motestatus": null,
     "latestOppfolgingstilfelle": {
       "oppfolgingstilfelleStart": "2022-01-01",
       "oppfolgingstilfelleEnd": "2022-12-31",
@@ -51,6 +59,8 @@
     "motebehovUbehandlet": true,
     "moteplanleggerUbehandlet": null,
     "oppfolgingsplanLPSBistandUbehandlet": true,
+    "dialogmotekandidat": null,
+    "motestatus": null,
     "latestOppfolgingstilfelle": {
       "oppfolgingstilfelleStart": "2022-01-01",
       "oppfolgingstilfelleEnd": "2022-12-31",
@@ -65,12 +75,23 @@
   {
     "fnr": "99999966666",
     "navn": "",
-    "enhet": "0317",
+    "enhet": "0316",
     "veilederIdent": "Z202020",
     "motebehovUbehandlet": null,
     "moteplanleggerUbehandlet": true,
     "oppfolgingsplanLPSBistandUbehandlet": null,
-    "latestOppfolgingstilfelle": null
+    "dialogmotekandidat": true,
+    "motestatus": "NYTT_TID_STED",
+    "latestOppfolgingstilfelle": {
+      "oppfolgingstilfelleStart": "2022-01-01",
+      "oppfolgingstilfelleEnd": "2022-12-31",
+      "virksomhetList": [
+        {
+          "virksomhetsnummer": "987654322",
+          "virksomhetsnavn": "NAV Investments"
+        }
+      ]
+    }
   },
   {
     "fnr": "99999955556",
@@ -80,37 +101,81 @@
     "motebehovUbehandlet": true,
     "moteplanleggerUbehandlet": null,
     "oppfolgingsplanLPSBistandUbehandlet": null,
-    "latestOppfolgingstilfelle": null
+    "dialogmotekandidat": true,
+    "motestatus": "INNKALT",
+    "latestOppfolgingstilfelle": {
+      "oppfolgingstilfelleStart": "2022-01-01",
+      "oppfolgingstilfelleEnd": "2022-12-31",
+      "virksomhetList": [
+        {
+          "virksomhetsnummer": "987654322",
+          "virksomhetsnavn": "NAV Investments"
+        }
+      ]
+    }
   },
   {
     "fnr": "99999966667",
     "navn": "",
-    "enhet": "0317",
+    "enhet": "0316",
     "veilederIdent": "Z202020",
     "motebehovUbehandlet": null,
     "moteplanleggerUbehandlet": true,
     "oppfolgingsplanLPSBistandUbehandlet": null,
-    "latestOppfolgingstilfelle": null
+    "dialogmotekandidat": true,
+    "motestatus": "AVLYST",
+    "latestOppfolgingstilfelle": {
+      "oppfolgingstilfelleStart": "2022-01-01",
+      "oppfolgingstilfelleEnd": "2022-12-31",
+      "virksomhetList": [
+        {
+          "virksomhetsnummer": "987654322",
+          "virksomhetsnavn": "NAV Investments"
+        }
+      ]
+    }
   },
   {
     "fnr": "99999966668",
     "navn": "",
-    "enhet": "0317",
+    "enhet": "0316",
     "veilederIdent": "Z202020",
     "motebehovUbehandlet": null,
     "moteplanleggerUbehandlet": true,
     "oppfolgingsplanLPSBistandUbehandlet": null,
-    "latestOppfolgingstilfelle": null
+    "dialogmotekandidat": true,
+    "motestatus": null,
+    "latestOppfolgingstilfelle": {
+      "oppfolgingstilfelleStart": "2022-01-01",
+      "oppfolgingstilfelleEnd": "2022-12-31",
+      "virksomhetList": [
+        {
+          "virksomhetsnummer": "987654322",
+          "virksomhetsnavn": "NAV Investments"
+        }
+      ]
+    }
   },
   {
     "fnr": "99999966669",
     "navn": "",
-    "enhet": "0317",
+    "enhet": "0316",
     "veilederIdent": "Z202020",
     "motebehovUbehandlet": null,
-    "moteplanleggerUbehandlet": true,
-    "oppfolgingsplanLPSBistandUbehandlet": null,
-    "latestOppfolgingstilfelle": null
+    "moteplanleggerUbehandlet": null,
+    "oppfolgingsplanLPSBistandUbehandlet": true,
+    "dialogmotekandidat": false,
+    "motestatus": "FERDIGSTILT",
+    "latestOppfolgingstilfelle": {
+      "oppfolgingstilfelleStart": "2022-01-01",
+      "oppfolgingstilfelleEnd": "2022-12-31",
+      "virksomhetList": [
+        {
+          "virksomhetsnummer": "987654322",
+          "virksomhetsnavn": "NAV Investments"
+        }
+      ]
+    }
   },
   {
     "fnr": "99999966670",
@@ -118,8 +183,199 @@
     "enhet": "0316",
     "veilederIdent": "Z202020",
     "motebehovUbehandlet": null,
+    "moteplanleggerUbehandlet": true,
+    "oppfolgingsplanLPSBistandUbehandlet": null,
+    "dialogmotekandidat": false,
+    "motestatus": null,
+    "latestOppfolgingstilfelle": {
+      "oppfolgingstilfelleStart": "2022-01-01",
+      "oppfolgingstilfelleEnd": "2022-12-31",
+      "virksomhetList": [
+        {
+          "virksomhetsnummer": "987654322",
+          "virksomhetsnavn": "NAV Investments"
+        }
+      ]
+    }
+  },
+  {
+    "fnr": "99999966671",
+    "navn": "",
+    "enhet": "0316",
+    "veilederIdent": "Z202020",
+    "motebehovUbehandlet": null,
     "moteplanleggerUbehandlet": null,
     "oppfolgingsplanLPSBistandUbehandlet": true,
+    "dialogmotekandidat": null,
+    "motestatus": null,
+    "latestOppfolgingstilfelle": {
+      "oppfolgingstilfelleStart": "2022-01-01",
+      "oppfolgingstilfelleEnd": "2022-12-31",
+      "virksomhetList": [
+        {
+          "virksomhetsnummer": "987654322",
+          "virksomhetsnavn": "NAV Investments"
+        }
+      ]
+    }
+  },
+  {
+    "fnr": "99999966672",
+    "navn": "",
+    "enhet": "0316",
+    "veilederIdent": "Z202020",
+    "motebehovUbehandlet": null,
+    "moteplanleggerUbehandlet": null,
+    "oppfolgingsplanLPSBistandUbehandlet": true,
+    "dialogmotekandidat": null,
+    "motestatus": null,
     "latestOppfolgingstilfelle": null
+  },
+  {
+    "fnr": "99999966673",
+    "navn": "Kandidat Endringsen",
+    "enhet": "0316",
+    "veilederIdent": "Z101010",
+    "motebehovUbehandlet": null,
+    "moteplanleggerUbehandlet": null,
+    "oppfolgingsplanLPSBistandUbehandlet": null,
+    "dialogmotekandidat": true,
+    "motestatus": "NYTT_TID_STED",
+    "latestOppfolgingstilfelle": {
+      "oppfolgingstilfelleStart": "2022-01-01",
+      "oppfolgingstilfelleEnd": "2022-12-31",
+      "virksomhetList": [
+        {
+          "virksomhetsnummer": "987654322",
+          "virksomhetsnavn": "NAV Investments"
+        }
+      ]
+    }
+  },
+  {
+    "fnr": "99999966674",
+    "navn": "Kandidat Innkaltsen",
+    "enhet": "0316",
+    "veilederIdent": "Z101010",
+    "motebehovUbehandlet": null,
+    "moteplanleggerUbehandlet": null,
+    "oppfolgingsplanLPSBistandUbehandlet": null,
+    "dialogmotekandidat": true,
+    "motestatus": "INNKALT",
+    "latestOppfolgingstilfelle": {
+      "oppfolgingstilfelleStart": "2022-01-01",
+      "oppfolgingstilfelleEnd": "2022-12-31",
+      "virksomhetList": [
+        {
+          "virksomhetsnummer": "987654322",
+          "virksomhetsnavn": "NAV Investments"
+        }
+      ]
+    }
+  },
+  {
+    "fnr": "99999966675",
+    "navn": "Kandidat Avlystsen",
+    "enhet": "0316",
+    "veilederIdent": "Z101010",
+    "motebehovUbehandlet": null,
+    "moteplanleggerUbehandlet": null,
+    "oppfolgingsplanLPSBistandUbehandlet": null,
+    "dialogmotekandidat": true,
+    "motestatus": "AVLYST",
+    "latestOppfolgingstilfelle": {
+      "oppfolgingstilfelleStart": "2022-01-01",
+      "oppfolgingstilfelleEnd": "2022-12-31",
+      "virksomhetList": [
+        {
+          "virksomhetsnummer": "987654322",
+          "virksomhetsnavn": "NAV Investments"
+        }
+      ]
+    }
+  },
+  {
+    "fnr": "99999966676",
+    "navn": "Kandidat Kandidatsen",
+    "enhet": "0316",
+    "veilederIdent": "Z101010",
+    "motebehovUbehandlet": null,
+    "moteplanleggerUbehandlet": null,
+    "oppfolgingsplanLPSBistandUbehandlet": null,
+    "dialogmotekandidat": true,
+    "motestatus": null,
+    "latestOppfolgingstilfelle": {
+      "oppfolgingstilfelleStart": "2022-01-01",
+      "oppfolgingstilfelleEnd": "2022-12-31",
+      "virksomhetList": [
+        {
+          "virksomhetsnummer": "987654322",
+          "virksomhetsnavn": "NAV Investments"
+        }
+      ]
+    }
+  },
+  {
+    "fnr": "99999966677",
+    "navn": "Ikke Viseson",
+    "enhet": "0316",
+    "veilederIdent": "Z101010",
+    "motebehovUbehandlet": null,
+    "moteplanleggerUbehandlet": null,
+    "oppfolgingsplanLPSBistandUbehandlet": null,
+    "dialogmotekandidat": false,
+    "motestatus": "FERDIGSTILT",
+    "latestOppfolgingstilfelle": {
+      "oppfolgingstilfelleStart": "2022-01-01",
+      "oppfolgingstilfelleEnd": "2022-12-31",
+      "virksomhetList": [
+        {
+          "virksomhetsnummer": "987654322",
+          "virksomhetsnavn": "NAV Investments"
+        }
+      ]
+    }
+  },
+  {
+    "fnr": "99999966678",
+    "navn": "Ikke Visesen",
+    "enhet": "0316",
+    "veilederIdent": "Z101010",
+    "motebehovUbehandlet": null,
+    "moteplanleggerUbehandlet": null,
+    "oppfolgingsplanLPSBistandUbehandlet": null,
+    "dialogmotekandidat": false,
+    "motestatus": null,
+    "latestOppfolgingstilfelle": {
+      "oppfolgingstilfelleStart": "2022-01-01",
+      "oppfolgingstilfelleEnd": "2022-12-31",
+      "virksomhetList": [
+        {
+          "virksomhetsnummer": "987654322",
+          "virksomhetsnavn": "NAV Investments"
+        }
+      ]
+    }
+  },
+  {
+    "fnr": "99999966678",
+    "navn": "Ikke Viseby",
+    "enhet": "0316",
+    "veilederIdent": "Z101010",
+    "motebehovUbehandlet": null,
+    "moteplanleggerUbehandlet": null,
+    "oppfolgingsplanLPSBistandUbehandlet": null,
+    "dialogmotekandidat": null,
+    "motestatus": null,
+    "latestOppfolgingstilfelle": {
+      "oppfolgingstilfelleStart": "2022-01-01",
+      "oppfolgingstilfelleEnd": "2022-12-31",
+      "virksomhetList": [
+        {
+          "virksomhetsnummer": "987654322",
+          "virksomhetsnavn": "NAV Investments"
+        }
+      ]
+    }
   }
 ]

--- a/mock/mockEndepunkter.ts
+++ b/mock/mockEndepunkter.ts
@@ -4,6 +4,7 @@ import { mockSyfoveileder } from './syfoveileder/mockSyfoveileder';
 import { mockPersonoversikt } from './personoversikt/mockPersonoversikt';
 import { mockPersontildeling } from './persontildeling/mockPersontildeling';
 import { mockChangelogs } from './changelogs/mockChangelogs';
+import { mockUnleash } from './unleash/mockUnleash';
 
 const mockUtils = require('./mockUtils.js');
 const express = require('express');
@@ -20,6 +21,7 @@ const mockEndepunkter = (server: any) => {
     mockSyfoperson,
     mockSyfoveileder,
     mockChangelogs,
+    mockUnleash,
   ].forEach((func) => {
     func(server, generatedPersons);
   });

--- a/mock/mockUtils.js
+++ b/mock/mockUtils.js
@@ -71,6 +71,8 @@ const generatePersonoversiktEnhetFromPersons = (persons) => {
       motebehovUbehandlet: null,
       moteplanleggerUbehandlet: true,
       oppfolgingsplanLPSBistandUbehandlet: null,
+      dialogmotekandidat: undefined,
+      motestatus: undefined,
     };
   });
 };

--- a/mock/unleash/unleashMock.ts
+++ b/mock/unleash/unleashMock.ts
@@ -1,4 +1,4 @@
-import { ToggleNames } from '@/data/unleash/types/unleash_types';
+import { ToggleNames } from '../../src/data/unleash/types/unleash_types';
 
 export const unleashMock = Object.values(ToggleNames).reduce(
   (accumulator, toggleName) => {

--- a/server.js
+++ b/server.js
@@ -9,6 +9,7 @@ const getChangelogs = require('./server/changelogReader.js');
 const Auth = require('./server/auth/index');
 
 const setupProxy = require('./server/proxy.js');
+const unleashRoutes = require("./server/routes/unleashRoutes");
 
 // Prometheus metrics
 const collectDefaultMetrics = prometheus.collectDefaultMetrics;
@@ -46,6 +47,9 @@ const setupServer = async () => {
 
   server.use('/static', express.static(DIST_DIR));
 
+  const unleashRoutes = require('./server/routes/unleashRoutes');
+  server.use('/unleash', unleashRoutes);
+
   server.use(setupProxy(authClient));
 
   server.get('/syfooversikt/changelogs', (req, res) => {
@@ -65,9 +69,6 @@ const setupServer = async () => {
       );
     }
   );
-
-  const unleashRoutes = require('./server/routes/unleashRoutes');
-  server.use('/unleash', unleashRoutes);
 
   server.get('/health/isAlive', (req, res) => {
     res.sendStatus(200);

--- a/src/api/types/personoversiktTypes.ts
+++ b/src/api/types/personoversiktTypes.ts
@@ -1,3 +1,10 @@
+export enum MoteStatusType {
+  INNKALT = 'INNKALT',
+  AVLYST = 'AVLYST',
+  FERDIGSTILT = 'FERDIGSTILT',
+  NYTT_TID_STED = 'NYTT_TID_STED',
+}
+
 export interface PersonOversiktStatusDTO {
   fnr: string;
   navn: string;
@@ -6,6 +13,8 @@ export interface PersonOversiktStatusDTO {
   motebehovUbehandlet: boolean | null;
   moteplanleggerUbehandlet: boolean | null;
   oppfolgingsplanLPSBistandUbehandlet: boolean | null;
+  dialogmotekandidat: boolean | undefined;
+  motestatus: MoteStatusType | undefined;
   latestOppfolgingstilfelle?: OppfolgingstilfelleDTO;
 }
 

--- a/src/api/types/personregisterTypes.ts
+++ b/src/api/types/personregisterTypes.ts
@@ -11,6 +11,7 @@ export interface PersonData {
   markert: boolean;
   tildeltEnhetId: string;
   tildeltVeilederIdent: string;
+  dialogmotekandidat?: boolean;
   latestOppfolgingstilfelle?: OppfolgingstilfelleDTO;
 }
 

--- a/src/utils/toPersondata.ts
+++ b/src/utils/toPersondata.ts
@@ -25,6 +25,7 @@ export const toPersonData = (
       markert: false,
       tildeltEnhetId: person.enhet,
       tildeltVeilederIdent: person.veilederIdent || '',
+      dialogmotekandidat: person?.dialogmotekandidat,
       latestOppfolgingstilfelle: person.latestOppfolgingstilfelle,
     };
   });

--- a/test/data/fellesTestdata.ts
+++ b/test/data/fellesTestdata.ts
@@ -53,6 +53,8 @@ export const personoversikt: PersonOversiktStatusDTO[] = [
     motebehovUbehandlet: true,
     moteplanleggerUbehandlet: true,
     oppfolgingsplanLPSBistandUbehandlet: null,
+    dialogmotekandidat: undefined,
+    motestatus: undefined,
   },
   {
     fnr: testdata.fnr4,
@@ -62,6 +64,8 @@ export const personoversikt: PersonOversiktStatusDTO[] = [
     motebehovUbehandlet: null,
     moteplanleggerUbehandlet: false,
     oppfolgingsplanLPSBistandUbehandlet: false,
+    dialogmotekandidat: undefined,
+    motestatus: undefined,
   },
 ];
 

--- a/test/utils/hendelseFilteringUtilsTest.ts
+++ b/test/utils/hendelseFilteringUtilsTest.ts
@@ -17,6 +17,7 @@ const createPersonDataWithName = (name: string): PersonData => {
     harOppfolgingsplanLPSBistandUbehandlet: false,
     tildeltEnhetId: '123',
     tildeltVeilederIdent: '234',
+    dialogmotekandidat: undefined,
     latestOppfolgingstilfelle: undefined,
   };
 };


### PR DESCRIPTION
If Dialogmotekandidat is toggled on, then show person that are Dialogmotekandidat and Dialogmote is not started. A Dialogmote is not started if Motestatus is  null or AVLYST.