### PR TITLE
Add uke column with sorting

### DIFF
--- a/mock/data/personoversiktEnhet.json
+++ b/mock/data/personoversiktEnhet.json
@@ -28,7 +28,17 @@
     "oppfolgingsplanLPSBistandUbehandlet": null,
     "dialogmotekandidat": null,
     "motestatus": null,
-    "dialogmotesvarUbehandlet": false
+    "dialogmotesvarUbehandlet": false,
+    "latestOppfolgingstilfelle": {
+      "oppfolgingstilfelleStart": "2022-10-25",
+      "oppfolgingstilfelleEnd": "2022-12-31",
+      "virksomhetList": [
+        {
+          "virksomhetsnummer": "987654321",
+          "virksomhetsnavn": "NAV Security"
+        }
+      ]
+    }
   },
   {
     "fnr": "99999944444",
@@ -41,7 +51,7 @@
     "motestatus": null,
     "dialogmotesvarUbehandlet": false,
     "latestOppfolgingstilfelle": {
-      "oppfolgingstilfelleStart": "2022-01-01",
+      "oppfolgingstilfelleStart": "2022-08-03",
       "oppfolgingstilfelleEnd": "2022-12-31",
       "virksomhetList": [
         {
@@ -62,7 +72,7 @@
     "motestatus": null,
     "dialogmotesvarUbehandlet": false,
     "latestOppfolgingstilfelle": {
-      "oppfolgingstilfelleStart": "2022-01-01",
+      "oppfolgingstilfelleStart": "2022-08-01",
       "oppfolgingstilfelleEnd": "2022-12-31",
       "virksomhetList": [
         {
@@ -146,7 +156,7 @@
     "motestatus": null,
     "dialogmotesvarUbehandlet": false,
     "latestOppfolgingstilfelle": {
-      "oppfolgingstilfelleStart": "2022-01-01",
+      "oppfolgingstilfelleStart": "2022-05-01",
       "oppfolgingstilfelleEnd": "2022-12-31",
       "virksomhetList": [
         {
@@ -167,7 +177,7 @@
     "motestatus": "FERDIGSTILT",
     "dialogmotesvarUbehandlet": false,
     "latestOppfolgingstilfelle": {
-      "oppfolgingstilfelleStart": "2022-01-01",
+      "oppfolgingstilfelleStart": "2022-10-01",
       "oppfolgingstilfelleEnd": "2022-12-31",
       "virksomhetList": [
         {

--- a/package-lock.json
+++ b/package-lock.json
@@ -5,6 +5,7 @@
   "requires": true,
   "packages": {
     "": {
+      "name": "syfooversikt",
       "version": "0.2.0",
       "license": "ISC",
       "dependencies": {

--- a/src/components/Personrad.tsx
+++ b/src/components/Personrad.tsx
@@ -13,6 +13,7 @@ import {
   firstCompanyNameFromPersonData,
 } from '@/utils/personDataUtil';
 import { useAktivBruker } from '@/data/modiacontext/useAktivBruker';
+import { getWeeksSinceDate } from '@/utils/dateUtils';
 
 interface PersonradProps {
   fnr: string;
@@ -65,6 +66,12 @@ export const Personrad = (props: PersonradProps): ReactElement => {
     aktivBruker.mutate(fnr);
   };
 
+  const startDatoOppfolgingstilfelle =
+    personData.latestOppfolgingstilfelle?.oppfolgingstilfelleStart;
+  const oppfolgingstilfelleLengthInWeeks = !!startDatoOppfolgingstilfelle
+    ? `Uke ${getWeeksSinceDate(startDatoOppfolgingstilfelle)}`
+    : 'Ukjent';
+
   return (
     <StyledPersonRad index={index} selected={kryssAv}>
       <Column xs={'1'}>
@@ -82,6 +89,7 @@ export const Personrad = (props: PersonradProps): ReactElement => {
       </Column>
       <Column xs={'2'}>{firstCompanyNameFromPersonData(personData)}</Column>
       <Column xs={'2'}>{veilederName}</Column>
+      <Column xs={'1'}>{oppfolgingstilfelleLengthInWeeks}</Column>
       <Column xs={'2'}>
         <NoWrapText>{skjermingskode(personData)}</NoWrapText>
       </Column>

--- a/src/components/Personrad.tsx
+++ b/src/components/Personrad.tsx
@@ -69,7 +69,7 @@ export const Personrad = (props: PersonradProps): ReactElement => {
   const startDatoOppfolgingstilfelle =
     personData.latestOppfolgingstilfelle?.oppfolgingstilfelleStart;
   const oppfolgingstilfelleLengthInWeeks = !!startDatoOppfolgingstilfelle
-    ? `Uke ${getWeeksSinceDate(startDatoOppfolgingstilfelle)}`
+    ? `${getWeeksSinceDate(startDatoOppfolgingstilfelle)} uker`
     : 'Ukjent';
 
   return (

--- a/src/components/Sorteringsrad.tsx
+++ b/src/components/Sorteringsrad.tsx
@@ -13,7 +13,7 @@ const tekster = {
   overskriftBruker: 'Bruker',
   overskriftVeileder: 'Veileder',
   virksomhet: 'Virksomhet',
-  uke: 'Uke',
+  varighetSykefravar: 'Varighet sykefravær',
 };
 
 export const GrayChevron = styled(Chevron)`
@@ -138,7 +138,7 @@ const Sorteringsrad = ({ onSortClick }: SortingRowProps): ReactElement => {
       xs: '2',
     },
     {
-      sortingText: tekster.uke,
+      sortingText: tekster.varighetSykefravar,
       extraText: null,
       sortingTypeAsc: 'UKE_ASC',
       sortingTypeDesc: 'UKE_DESC',

--- a/src/components/Sorteringsrad.tsx
+++ b/src/components/Sorteringsrad.tsx
@@ -13,6 +13,7 @@ const tekster = {
   overskriftBruker: 'Bruker',
   overskriftVeileder: 'Veileder',
   virksomhet: 'Virksomhet',
+  uke: 'Uke',
 };
 
 export const GrayChevron = styled(Chevron)`
@@ -135,6 +136,13 @@ const Sorteringsrad = ({ onSortClick }: SortingRowProps): ReactElement => {
       sortingTypeAsc: 'VEILEDER_ASC',
       sortingTypeDesc: 'VEILEDER_DESC',
       xs: '2',
+    },
+    {
+      sortingText: tekster.uke,
+      extraText: null,
+      sortingTypeAsc: 'UKE_ASC',
+      sortingTypeDesc: 'UKE_DESC',
+      xs: '1',
     },
   ];
 

--- a/src/components/toolbar/Toolbar.tsx
+++ b/src/components/toolbar/Toolbar.tsx
@@ -109,6 +109,7 @@ const Toolbar = (props: ToolbarProps) => {
             props.setSortingType(type);
           }}
         />
+        <Column xs={'2'} />
       </IngressRad>
     </ToolbarStyled>
   );

--- a/src/utils/dateUtils.ts
+++ b/src/utils/dateUtils.ts
@@ -1,0 +1,12 @@
+const ONE_WEEK_MILLIS = 7 * 24 * 60 * 60 * 1000;
+
+export const getWeeksSinceDate = (date: Date): number => {
+  const now = new Date();
+  return getWeeksBetween(new Date(date), now);
+};
+
+export const getWeeksBetween = (date1: Date, date2: Date): number => {
+  return Math.round(
+    Math.abs(date1.getTime() - date2.getTime()) / ONE_WEEK_MILLIS
+  );
+};

--- a/src/utils/hendelseFilteringUtils.tsx
+++ b/src/utils/hendelseFilteringUtils.tsx
@@ -135,6 +135,8 @@ export type SortingType =
   | 'COMPANY_DESC'
   | 'VEILEDER_ASC'
   | 'VEILEDER_DESC'
+  | 'UKE_ASC'
+  | 'UKE_DESC'
   | 'NONE';
 
 export const getSortedEventsFromSortingType = (
@@ -150,6 +152,8 @@ export const getSortedEventsFromSortingType = (
     return sortEventsOnCompanyName(personregister, type);
   } else if (type === 'VEILEDER_ASC' || type === 'VEILEDER_DESC') {
     return sortEventsOnVeileder(personregister, veiledere, type);
+  } else if (type === 'UKE_ASC' || type === 'UKE_DESC') {
+    return sortEventsOnWeek(personregister, type);
   }
   return personregister;
 };
@@ -231,4 +235,25 @@ const sortEventsOnName = (
   return order === 'NAME_ASC'
     ? Object.fromEntries(sorted)
     : Object.fromEntries(sorted.reverse());
+};
+
+const sortEventsOnWeek = (
+  personregister: PersonregisterState,
+  order: SortingType
+): PersonregisterState => {
+  const sorted = Object.entries(personregister).sort(
+    ([, persondataA], [, persondataB]) => {
+      const startDateA =
+        persondataA.latestOppfolgingstilfelle?.oppfolgingstilfelleStart;
+      const startDateB =
+        persondataB.latestOppfolgingstilfelle?.oppfolgingstilfelleStart;
+      if (!startDateA) return order === 'UKE_ASC' ? -1 : 1;
+      if (!startDateB) return order === 'UKE_ASC' ? 1 : -1;
+      if (startDateA > startDateB) return order === 'UKE_ASC' ? -1 : 1;
+      if (startDateA < startDateB) return order === 'UKE_ASC' ? 1 : -1;
+      return 0;
+    }
+  );
+
+  return Object.fromEntries(sorted);
 };

--- a/test/utils/dateUtils.test.ts
+++ b/test/utils/dateUtils.test.ts
@@ -1,0 +1,12 @@
+import { expect } from 'chai';
+import { getWeeksBetween } from '@/utils/dateUtils';
+
+describe('dateUtils', () => {
+  describe('week calculations', () => {
+    it('Will calculate number of weeks between two dates', () => {
+      const date1 = new Date('2022-10-01');
+      const date2 = new Date('2022-10-14');
+      expect(getWeeksBetween(date1, date2)).to.equal(2);
+    });
+  });
+});


### PR DESCRIPTION
Kolonnen viser antall uker siden sykemeldingen oppsto, og skal hjelpe veiledere med å kunne prioritere sakene sine enklere på tvers av filtergrupperinger.

`undefined`-verdier rangeres "lavere" enn 0, fordi man helst vil se på de som er høyest antall uker siden, og da vil man ikke at "Ukjent" skal dukke opp der (hvis ukjent i det hele tatt er en greie i prod).
<img width="1335" alt="image" src="https://user-images.githubusercontent.com/37441744/198008884-c40c847f-66ec-40d8-8aea-0ef8f057aa0f.png">
