### PR TITLE
Use aktivitetskravActive, add missing enum value

### DIFF
--- a/mock/data/personoversiktEnhet.json
+++ b/mock/data/personoversiktEnhet.json
@@ -92,7 +92,7 @@
     "motestatus": null,
     "dialogmotesvarUbehandlet": false,
     "aktivitetskrav": "AVVENT",
-    "aktivitetskravStoppunkt": "2023-01-10",
+    "aktivitetskravActive": true,
     "aktivitetskravSistVurdert":  "2022-12-01T10:12:05.913826",
     "latestOppfolgingstilfelle": {
       "oppfolgingstilfelleStart": "2022-08-01",
@@ -121,7 +121,7 @@
     "motestatus": "NYTT_TID_STED",
     "dialogmotesvarUbehandlet": false,
     "aktivitetskrav": "AVVENT",
-    "aktivitetskravStoppunkt": "2023-01-10",
+    "aktivitetskravActive": false,
     "aktivitetskravSistVurdert":  "1984-01-19T10:12:05.913826",
     "latestOppfolgingstilfelle": {
       "oppfolgingstilfelleStart": "2022-01-01",
@@ -145,7 +145,7 @@
     "motestatus": "INNKALT",
     "dialogmotesvarUbehandlet": true,
     "aktivitetskrav": "NY",
-    "aktivitetskravStoppunkt": "2023-03-15",
+    "aktivitetskravActive": true,
     "aktivitetskravSistVurdert":  "2022-12-01T10:12:05.913826",
     "latestOppfolgingstilfelle": {
       "oppfolgingstilfelleStart": "2022-01-01",
@@ -169,7 +169,7 @@
     "motestatus": "AVLYST",
     "dialogmotesvarUbehandlet": false,
     "aktivitetskrav": "STANS",
-    "aktivitetskravStoppunkt": "2023-01-10",
+    "aktivitetskravActive": false,
     "aktivitetskravSistVurdert":  "2022-12-01T10:12:05.913826",
     "latestOppfolgingstilfelle": {
       "oppfolgingstilfelleStart": "2022-01-01",
@@ -193,7 +193,7 @@
     "motestatus": null,
     "dialogmotesvarUbehandlet": false,
     "aktivitetskrav": "AVVENT",
-    "aktivitetskravStoppunkt": "2023-01-10",
+    "aktivitetskravActive": false,
     "aktivitetskravSistVurdert":  "2022-12-01T10:12:05.913826",
     "latestOppfolgingstilfelle": {
       "oppfolgingstilfelleStart": "2022-05-01",
@@ -217,7 +217,7 @@
     "motestatus": "FERDIGSTILT",
     "dialogmotesvarUbehandlet": false,
     "aktivitetskrav": "UNNTAK",
-    "aktivitetskravStoppunkt": "2023-01-10",
+    "aktivitetskravActive": false,
     "aktivitetskravSistVurdert":  "2022-12-01T10:12:05.913826",
     "latestOppfolgingstilfelle": {
       "oppfolgingstilfelleStart": "2022-10-01",
@@ -245,7 +245,7 @@
     "motestatus": null,
     "dialogmotesvarUbehandlet": false,
     "aktivitetskrav": "AUTOMATISK_OPPFYLT",
-    "aktivitetskravStoppunkt": "2023-01-10",
+    "aktivitetskravActive": false,
     "aktivitetskravSistVurdert":  "2022-12-01T10:12:05.913826",
     "latestOppfolgingstilfelle": {
       "oppfolgingstilfelleStart": "2022-01-01",
@@ -269,7 +269,7 @@
     "motestatus": null,
     "dialogmotesvarUbehandlet": false,
     "aktivitetskrav": "NY",
-    "aktivitetskravStoppunkt": "2023-01-10",
+    "aktivitetskravActive": false,
     "aktivitetskravSistVurdert":  "2022-12-01T10:12:05.913826",
     "latestOppfolgingstilfelle": {
       "oppfolgingstilfelleStart": "2022-01-01",
@@ -294,7 +294,7 @@
     "dialogmotesvarUbehandlet": false,
     "latestOppfolgingstilfelle": null,
     "aktivitetskrav": "OPPFYLT",
-    "aktivitetskravStoppunkt": "2023-01-10",
+    "aktivitetskravActive": false,
     "aktivitetskravSistVurdert":  "2022-12-01T10:12:05.913826"
   },
   {
@@ -307,8 +307,8 @@
     "dialogmotekandidat": false,
     "motestatus": "NYTT_TID_STED",
     "dialogmotesvarUbehandlet": false,
-    "aktivitetskrav": "AVVENT",
-    "aktivitetskravStoppunkt": "2023-01-10",
+    "aktivitetskrav": "IKKE_OPPFYLT",
+    "aktivitetskravActive": false,
     "aktivitetskravSistVurdert":  "2022-10-01T10:12:05.913826",
     "latestOppfolgingstilfelle": {
       "oppfolgingstilfelleStart": "2022-01-01",
@@ -332,7 +332,7 @@
     "motestatus": "INNKALT",
     "dialogmotesvarUbehandlet": false,
     "aktivitetskrav": "NY",
-    "aktivitetskravStoppunkt": "2023-01-10",
+    "aktivitetskravActive": false,
     "aktivitetskravSistVurdert":  "2022-12-01T10:12:05.913826",
     "latestOppfolgingstilfelle": {
       "oppfolgingstilfelleStart": "2022-01-01",
@@ -356,7 +356,7 @@
     "motestatus": "AVLYST",
     "dialogmotesvarUbehandlet": false,
     "aktivitetskrav": "AVVENT",
-    "aktivitetskravStoppunkt": "2023-01-10",
+    "aktivitetskravActive": false,
     "aktivitetskravSistVurdert":  "2020-12-01T10:12:05.913826",
     "latestOppfolgingstilfelle": {
       "oppfolgingstilfelleStart": "2022-01-01",

--- a/src/api/types/personoversiktTypes.ts
+++ b/src/api/types/personoversiktTypes.ts
@@ -13,6 +13,7 @@ export enum AktivitetskravStatus {
   OPPFYLT = 'OPPFYLT',
   AUTOMATISK_OPPFYLT = 'AUTOMATISK_OPPFYLT',
   STANS = 'STANS',
+  IKKE_OPPFYLT = 'IKKE_OPPFYLT',
 }
 
 export interface PersonOversiktStatusDTO {
@@ -27,8 +28,8 @@ export interface PersonOversiktStatusDTO {
   motestatus: MoteStatusType | undefined;
   latestOppfolgingstilfelle?: OppfolgingstilfelleDTO;
   aktivitetskrav: AktivitetskravStatus | null;
-  aktivitetskravStoppunkt: Date | null;
   aktivitetskravSistVurdert: Date | null;
+  aktivitetskravActive: boolean;
 }
 
 export interface OppfolgingstilfelleDTO {

--- a/src/api/types/personregisterTypes.ts
+++ b/src/api/types/personregisterTypes.ts
@@ -25,8 +25,8 @@ export interface PersonData {
   dialogmotekandidat?: boolean;
   latestOppfolgingstilfelle?: OppfolgingstilfelleDTO;
   aktivitetskrav: AktivitetskravStatus | null;
-  aktivitetskravStoppunkt: Date | null;
   aktivitetskravSistVurdert: Date | null;
+  aktivitetskravActive: boolean;
 }
 
 export interface PersonregisterState {

--- a/src/data/personoversiktHooks.ts
+++ b/src/data/personoversiktHooks.ts
@@ -1,8 +1,5 @@
 import { useQuery } from '@tanstack/react-query';
-import {
-  AktivitetskravStatus,
-  PersonOversiktStatusDTO,
-} from '@/api/types/personoversiktTypes';
+import { PersonOversiktStatusDTO } from '@/api/types/personoversiktTypes';
 import { SYFOOVERSIKTSRVREST_ROOT } from '@/utils/apiUrlUtil';
 import { get } from '@/api/axios';
 import { useAktivEnhet } from '@/context/aktivEnhet/AktivEnhetContext';
@@ -14,7 +11,6 @@ import { minutesToMillis } from '@/utils/timeUtils';
 import { useMemo } from 'react';
 import { useFeatureToggles } from '@/data/unleash/unleashQueryHooks';
 import { ToggleNames } from '@/data/unleash/types/unleash_types';
-import dayjs from 'dayjs';
 
 const isUbehandlet = (personOversiktStatus: PersonOversiktStatusDTO) => {
   return (
@@ -25,18 +21,6 @@ const isUbehandlet = (personOversiktStatus: PersonOversiktStatusDTO) => {
   );
 };
 
-const needsAktivitetskravVurdering = (
-  personOversiktStatus: PersonOversiktStatusDTO
-) => {
-  const arenaCutoff = dayjs('2023-03-10');
-  return (
-    (personOversiktStatus.aktivitetskrav === AktivitetskravStatus.NY ||
-      personOversiktStatus.aktivitetskrav === AktivitetskravStatus.AVVENT) &&
-    !!personOversiktStatus.aktivitetskravStoppunkt &&
-    dayjs(personOversiktStatus.aktivitetskravStoppunkt).isAfter(arenaCutoff)
-  );
-};
-
 const filteredPersonOversiktStatusList = (
   personOversiktStatusList: PersonOversiktStatusDTO[],
   isAktivitetskravTurnedOn: boolean
@@ -44,8 +28,7 @@ const filteredPersonOversiktStatusList = (
   return personOversiktStatusList.filter(
     (personOversiktStatus) =>
       isUbehandlet(personOversiktStatus) ||
-      (isAktivitetskravTurnedOn &&
-        needsAktivitetskravVurdering(personOversiktStatus))
+      (isAktivitetskravTurnedOn && personOversiktStatus.aktivitetskravActive)
   );
 };
 

--- a/src/utils/hendelseFilteringUtils.tsx
+++ b/src/utils/hendelseFilteringUtils.tsx
@@ -2,10 +2,7 @@ import {
   PersonData,
   PersonregisterState,
 } from '@/api/types/personregisterTypes';
-import {
-  firstCompanyNameFromPersonData,
-  hasActiveAktivitetskravStatus,
-} from './personDataUtil';
+import { firstCompanyNameFromPersonData } from './personDataUtil';
 import { Veileder } from '@/api/types/veiledereTypes';
 import { HendelseTypeFilters } from '@/context/filters/filterContextState';
 
@@ -108,10 +105,7 @@ export const filterOnPersonregister = (
       return true;
     } else if (filter.dialogmotesvar && personData.harDialogmotesvar) {
       return true;
-    } else if (
-      filter.aktivitetskrav &&
-      hasActiveAktivitetskravStatus(personData)
-    ) {
+    } else if (filter.aktivitetskrav && personData.aktivitetskravActive) {
       return true;
     }
   });

--- a/src/utils/lenkeUtil.tsx
+++ b/src/utils/lenkeUtil.tsx
@@ -4,7 +4,6 @@ import { PersonData } from '@/api/types/personregisterTypes';
 import { fullNaisUrlDefault } from './miljoUtil';
 import { capitalizeHyphenatedWords } from './stringUtil';
 import { trackOnClick } from '@/amplitude/amplitude';
-import { hasActiveAktivitetskravStatus } from '@/utils/personDataUtil';
 
 const texts = {
   trackingLabelNavigateToModiaPerson: 'Gå til Syfomodiaperson',
@@ -18,7 +17,7 @@ export const lenkeTilModia = (personData: PersonData) => {
     personData.dialogmotekandidat;
   const isGoingToOppfolgingsplanOversikt =
     personData.harOppfolgingsplanLPSBistandUbehandlet;
-  const isGoingToAktivitetskrav = hasActiveAktivitetskravStatus(personData);
+  const isGoingToAktivitetskrav = personData.aktivitetskravActive;
   if (isGoingToOppfolgingsplanOversikt) {
     path = `${path}/oppfoelgingsplaner`;
   } else if (isGoingToMoteoversikt) {

--- a/src/utils/personDataUtil.ts
+++ b/src/utils/personDataUtil.ts
@@ -4,8 +4,6 @@ import {
   ReadableSkjermingskodeMap,
   Skjermingskode,
 } from '@/api/types/personregisterTypes';
-import { AktivitetskravStatus } from '@/api/types/personoversiktTypes';
-import dayjs from 'dayjs';
 
 const readableSkjermingskoder: ReadableSkjermingskodeMap = {
   INGEN: 'ingen',
@@ -38,14 +36,4 @@ export const firstCompanyNameFromPersonData = (
   p: PersonData
 ): string | undefined => {
   return companyNamesFromPersonData(p).shift();
-};
-
-export const hasActiveAktivitetskravStatus = (personData: PersonData) => {
-  const arenaCutoff = dayjs('2023-03-10');
-  return (
-    (personData.aktivitetskrav === AktivitetskravStatus.NY ||
-      personData.aktivitetskrav === AktivitetskravStatus.AVVENT) &&
-    !!personData.aktivitetskravStoppunkt &&
-    dayjs(personData.aktivitetskravStoppunkt).isAfter(arenaCutoff)
-  );
 };

--- a/src/utils/toPersondata.ts
+++ b/src/utils/toPersondata.ts
@@ -28,8 +28,8 @@ export const toPersonData = (
       dialogmotekandidat: person?.dialogmotekandidat,
       latestOppfolgingstilfelle: person.latestOppfolgingstilfelle,
       aktivitetskrav: person.aktivitetskrav,
-      aktivitetskravStoppunkt: person.aktivitetskravStoppunkt,
       aktivitetskravSistVurdert: person.aktivitetskravSistVurdert,
+      aktivitetskravActive: person.aktivitetskravActive,
     };
   });
 

--- a/test/components/Personrad.test.tsx
+++ b/test/components/Personrad.test.tsx
@@ -43,7 +43,7 @@ describe('Personrad', () => {
       tildeltVeilederIdent: '234',
       aktivitetskrav: null,
       aktivitetskravSistVurdert: null,
-      aktivitetskravStoppunkt: null,
+      aktivitetskravActive: false,
     };
     renderPersonrad(personData);
 
@@ -65,7 +65,7 @@ describe('Personrad', () => {
       tildeltVeilederIdent: '234',
       aktivitetskrav: AktivitetskravStatus.AVVENT,
       aktivitetskravSistVurdert: new Date('2022-12-01'),
-      aktivitetskravStoppunkt: new Date('2022-12-01'),
+      aktivitetskravActive: true,
     };
     renderPersonrad(personData);
 

--- a/test/data/fellesTestdata.ts
+++ b/test/data/fellesTestdata.ts
@@ -38,7 +38,7 @@ export const personregister: PersonregisterState = {
     tildeltVeilederIdent: 'Z999999',
     aktivitetskrav: AktivitetskravStatus.NY,
     aktivitetskravSistVurdert: new Date(),
-    aktivitetskravStoppunkt: new Date(),
+    aktivitetskravActive: true,
   } as PersonData,
   [testdata.fnr2]: {
     navn: testdata.navn2,
@@ -49,7 +49,7 @@ export const personregister: PersonregisterState = {
     tildeltVeilederIdent: 'Z999999',
     aktivitetskrav: null,
     aktivitetskravSistVurdert: null,
-    aktivitetskravStoppunkt: null,
+    aktivitetskravActive: false,
   } as PersonData,
 };
 
@@ -66,7 +66,7 @@ export const personoversikt: PersonOversiktStatusDTO[] = [
     motestatus: undefined,
     aktivitetskrav: null,
     aktivitetskravSistVurdert: null,
-    aktivitetskravStoppunkt: null,
+    aktivitetskravActive: false,
   },
   {
     fnr: testdata.fnr4,
@@ -80,7 +80,7 @@ export const personoversikt: PersonOversiktStatusDTO[] = [
     motestatus: undefined,
     aktivitetskrav: null,
     aktivitetskravSistVurdert: null,
-    aktivitetskravStoppunkt: null,
+    aktivitetskravActive: false,
   },
 ];
 

--- a/test/utils/hendelseFilteringUtilsTest.ts
+++ b/test/utils/hendelseFilteringUtilsTest.ts
@@ -21,7 +21,7 @@ const createPersonDataWithName = (name: string): PersonData => {
     latestOppfolgingstilfelle: undefined,
     aktivitetskrav: null,
     aktivitetskravSistVurdert: null,
-    aktivitetskravStoppunkt: null,
+    aktivitetskravActive: false,
   };
 };
 

--- a/test/utils/personDataUtil.test.ts
+++ b/test/utils/personDataUtil.test.ts
@@ -3,13 +3,8 @@ import {
   PersonData,
   ReadableSkjermingskode,
 } from '@/api/types/personregisterTypes';
-import {
-  getReadableSkjermingskode,
-  hasActiveAktivitetskravStatus,
-} from '@/utils/personDataUtil';
+import { getReadableSkjermingskode } from '@/utils/personDataUtil';
 import { testdata } from '../data/fellesTestdata';
-import { AktivitetskravStatus } from '@/api/types/personoversiktTypes';
-import dayjs from 'dayjs';
 
 const INGEN: ReadableSkjermingskode = 'ingen';
 const EGEN_ANSATT: ReadableSkjermingskode = 'egen ansatt';
@@ -39,101 +34,6 @@ describe('personDataUtils', () => {
       const returnertString = getReadableSkjermingskode(person.skjermingskode);
 
       expect(returnertString).to.equal(INGEN);
-    });
-  });
-
-  describe('hasAktivAktivitetskravStatus', () => {
-    it('return true if AktivitetskravStatus is NY and stoppunkt after arena cutoff', () => {
-      const person = {
-        aktivitetskrav: AktivitetskravStatus.NY,
-        aktivitetskravStoppunkt: dayjs('2023-03-11').toDate(),
-      } as PersonData;
-
-      const isActive = hasActiveAktivitetskravStatus(person);
-
-      expect(isActive).to.equal(true);
-    });
-
-    it('return true if AktivitetskravStatus is AVVENT and stoppunkt after arena cutoff', () => {
-      const person = {
-        aktivitetskrav: AktivitetskravStatus.AVVENT,
-        aktivitetskravStoppunkt: dayjs('2023-03-11').toDate(),
-      } as PersonData;
-
-      const isActive = hasActiveAktivitetskravStatus(person);
-
-      expect(isActive).to.equal(true);
-    });
-    it('return false if AktivitetskravStatus is NY and stoppunkt equal arena cutoff', () => {
-      const person = {
-        aktivitetskrav: AktivitetskravStatus.NY,
-        aktivitetskravStoppunkt: dayjs('2023-03-10').toDate(),
-      } as PersonData;
-
-      const isActive = hasActiveAktivitetskravStatus(person);
-
-      expect(isActive).to.equal(false);
-    });
-
-    it('return false if AktivitetskravStatus is AVVENT and stoppunkt before arena cutoff', () => {
-      const person = {
-        aktivitetskrav: AktivitetskravStatus.AVVENT,
-        aktivitetskravStoppunkt: dayjs('2023-03-09').toDate(),
-      } as PersonData;
-
-      const isActive = hasActiveAktivitetskravStatus(person);
-
-      expect(isActive).to.equal(false);
-    });
-
-    it('return false if AktivitetskravStatus is AVVENT and stoppunkt missing', () => {
-      const person = {
-        aktivitetskrav: AktivitetskravStatus.AVVENT,
-      } as PersonData;
-
-      const isActive = hasActiveAktivitetskravStatus(person);
-
-      expect(isActive).to.equal(false);
-    });
-
-    it('return false if AktivitetskravStatus is OPPFYLT', () => {
-      const person = {
-        aktivitetskrav: AktivitetskravStatus.OPPFYLT,
-      } as PersonData;
-
-      const isActive = hasActiveAktivitetskravStatus(person);
-
-      expect(isActive).to.equal(false);
-    });
-
-    it('return false if AktivitetskravStatus is AUTOMATISK_OPPFYLT', () => {
-      const person = {
-        aktivitetskrav: AktivitetskravStatus.AUTOMATISK_OPPFYLT,
-      } as PersonData;
-
-      const isActive = hasActiveAktivitetskravStatus(person);
-
-      expect(isActive).to.equal(false);
-    });
-
-    it('return false if AktivitetskravStatus is STANS', () => {
-      const person = {
-        aktivitetskrav: AktivitetskravStatus.STANS,
-      } as PersonData;
-
-      const isActive = hasActiveAktivitetskravStatus(person);
-
-      expect(isActive).to.equal(false);
-    });
-
-    it('return false if AktivitetskravStatus is UNNTAK', () => {
-      const person = {
-        aktivitetskrav: AktivitetskravStatus.UNNTAK,
-      } as PersonData;
-
-      const isActive = hasActiveAktivitetskravStatus(person);
-
-      expect(isActive).to.equal(false);
     });
   });
 });


### PR DESCRIPTION
Bruker nytt felt på dto i stedet for å duplisere logikk for sjekk på status og stoppunkt > cutoff.
Kan merges etter https://github.com/navikt/syfooversiktsrv/pull/260