### PR TITLE
Lagre siste filter i sessionStorage

### DIFF
--- a/src/components/NavigationBar.tsx
+++ b/src/components/NavigationBar.tsx
@@ -1,8 +1,6 @@
 import React, { ReactElement } from 'react';
 import { NavLink } from 'react-router-dom';
 import styled from 'styled-components';
-import { useFilters } from '@/context/filters/FilterContext';
-import { ActionType } from '@/context/filters/filterContextActions';
 import { trackOnClick } from '@/amplitude/amplitude';
 import { MoteoversiktLink } from '@/components/MoteoversiktLink';
 import {
@@ -68,32 +66,20 @@ const MoteoversiktLinkContent = styled.div`
 `;
 
 export const NavigationBar = (): ReactElement => {
-  const { dispatch } = useFilters();
-
   return (
     <NavigationBarDiv>
       <NavigationBarContent>
         <LinkStyled
           className={({ isActive }) => (isActive ? 'active' : '')}
           to={minOversiktRoutePathRoutePath}
-          onClick={() => {
-            trackOnClick(tekster.minOversikt);
-            dispatch({
-              type: ActionType.ResetFilters,
-            });
-          }}
+          onClick={() => trackOnClick(tekster.minOversikt)}
         >
           {tekster.minOversikt}
         </LinkStyled>
         <LinkStyled
           className={({ isActive }) => (isActive ? 'active' : '')}
           to={enhetOversiktRoutePath}
-          onClick={() => {
-            trackOnClick(tekster.enhetensOversikt);
-            dispatch({
-              type: ActionType.ResetFilters,
-            });
-          }}
+          onClick={() => trackOnClick(tekster.enhetensOversikt)}
         >
           {tekster.enhetensOversikt}
         </LinkStyled>

--- a/src/components/Sokeresultat.tsx
+++ b/src/components/Sokeresultat.tsx
@@ -17,6 +17,7 @@ import { useFilters } from '@/context/filters/FilterContext';
 import { useTabType } from '@/context/tab/TabTypeContext';
 import { useAktivEnhet } from '@/context/aktivEnhet/AktivEnhetContext';
 import { trackOnClick } from '@/amplitude/amplitude';
+import { OverviewTabType } from '@/konstanter';
 
 interface SokeresultatProps {
   allEvents: Filterable<PersonregisterState>;
@@ -57,12 +58,18 @@ const Sokeresultat = ({ allEvents }: SokeresultatProps) => {
     setMarkertePersoner([]);
   }, [tabType]);
 
+  const selectedHendelsetypeFilter =
+    tabType === OverviewTabType.MY_OVERVIEW
+      ? {
+          ...filterState.selectedHendelseType,
+          ufordeltBruker: false,
+        }
+      : filterState.selectedHendelseType;
+
   const filteredEvents = allEvents
     .applyFilter((v) => filterOnCompany(v, filterState.selectedCompanies))
     .applyFilter((v) => filterOnBirthDates(v, filterState.selectedBirthDates))
-    .applyFilter((v) =>
-      filterOnPersonregister(v, filterState.selectedHendelseType)
-    )
+    .applyFilter((v) => filterOnPersonregister(v, selectedHendelsetypeFilter))
     .applyFilter((v) =>
       filterOnFodselsnummerOrName(v, filterState.tekstFilter)
     );

--- a/src/context/filters/FilterContext.tsx
+++ b/src/context/filters/FilterContext.tsx
@@ -5,6 +5,7 @@ import {
 } from '@/context/filters/filterContextState';
 import { filterReducer } from '@/context/filters/filterContextReducer';
 import { FilterActions } from '@/context/filters/filterContextActions';
+import { useEffect } from 'react';
 
 type FilterProviderProps = { children: React.ReactNode };
 
@@ -17,10 +18,15 @@ const FilterContext = React.createContext<{
 });
 
 const FilterProvider = ({ children }: FilterProviderProps) => {
-  const [filterState, dispatch] = React.useReducer(
-    filterReducer,
-    filterInitialState
-  );
+  const storeKey = 'filters';
+  const storedFilters = sessionStorage.getItem(storeKey);
+  const initialState =
+    storedFilters === null ? filterInitialState : JSON.parse(storedFilters);
+  const [filterState, dispatch] = React.useReducer(filterReducer, initialState);
+  useEffect(() => {
+    sessionStorage.setItem(storeKey, JSON.stringify(filterState));
+  }, [filterState]);
+
   return (
     <FilterContext.Provider value={{ filterState, dispatch }}>
       {children}


### PR DESCRIPTION
Dette vil ta vare på siste filter f.eks. når man går mellom enhetens oversikt og sykmeldt enkeltperson. ~~Filter nullstilles når man bytter mellom Min oversikt og Enhetens oversikt, så det må vi eventuelt løse ved å lagre siste filter per oversikt på et vis.~~
Endret også slik at vi ikke nullstiller filter når man bytter mellom Min oversikt og Enhetens oversikt, dvs at vi lagrer siste filter på tvers av oversiktene.

OBS: Dersom veileder filtrerer på fødselsnummer vil sessionStorage i nettleseren inneholde hele/deler av fødselsnummer i json-strukturen, men tenker kanskje det er greit siden dette er i en intern app og sessionStorage slettes når fanen lukkes.