### PR TITLE
Use intersection instead of union when filtering

### DIFF
--- a/src/utils/hendelseFilteringUtils.tsx
+++ b/src/utils/hendelseFilteringUtils.tsx
@@ -92,27 +92,16 @@ export const filterOnPersonregister = (
   }
 
   const filtered = Object.entries(personregister).filter(([, personData]) => {
-    if (filter.onskerMote && personData.harMotebehovUbehandlet) {
-      return true;
-    } else if (
-      filter.arbeidsgiverOnskerMote &&
-      personData.harOppfolgingsplanLPSBistandUbehandlet
-    ) {
-      return true;
-    } else if (filter.dialogmotekandidat && personData.dialogmotekandidat) {
-      return true;
-    } else if (filter.ufordeltBruker && !personData.tildeltVeilederIdent) {
-      return true;
-    } else if (filter.dialogmotesvar && personData.harDialogmotesvar) {
-      return true;
-    } else if (filter.aktivitetskrav && personData.aktivitetskravActive) {
-      return true;
-    } else if (
-      filter.behandlerdialog &&
-      personData.harBehandlerdialogUbehandlet
-    ) {
-      return true;
-    }
+    return (
+      (!filter.onskerMote || personData.harMotebehovUbehandlet) &&
+      (!filter.arbeidsgiverOnskerMote ||
+        personData.harOppfolgingsplanLPSBistandUbehandlet) &&
+      (!filter.dialogmotekandidat || personData.dialogmotekandidat) &&
+      (!filter.ufordeltBruker || !personData.tildeltVeilederIdent) &&
+      (!filter.dialogmotesvar || personData.harDialogmotesvar) &&
+      (!filter.aktivitetskrav || personData.aktivitetskravActive) &&
+      (!filter.behandlerdialog || personData.harBehandlerdialogUbehandlet)
+    );
   });
 
   return Object.fromEntries(filtered);


### PR DESCRIPTION
Jeg er usikker på hvor lett det er å skjønne hvorfor filteret ser ut som det gjør 🤔 I forrige utgave av koden kunne man returnere true med én gang man fikk match på filter/personData, eller default true hvis ingen ifer slo til (ingen filter var huket av). Det kan man ikke nå, siden man alltid må sjekke alle filtrene.

Tanken er at hvis et filter ikke er huket av, skal det ikke fjerne noe fra listen (return true som default), men hvis filteret er huket av må vi også sjekke om tilhørende verdi i personData er true (eller false for tildeltVeileder).
Første utkast var på formen `!filter.verdi || (filter.verdi && personData.verdi))`. Men hvis `!filter.verdi` ikke slår til, må den jo være true, så da kan vi droppe den sjekken etter `||`.