### PR TITLE
Use correct link when person has behandlerdialog-oppgave

### DIFF
--- a/src/utils/lenkeUtil.tsx
+++ b/src/utils/lenkeUtil.tsx
@@ -18,12 +18,16 @@ export const lenkeTilModia = (personData: PersonData) => {
   const isGoingToOppfolgingsplanOversikt =
     personData.harOppfolgingsplanLPSBistandUbehandlet;
   const isGoingToAktivitetskrav = personData.aktivitetskravActive;
+  const isGoingToBehandlerdialog = personData.harBehandlerdialogUbehandlet;
+
   if (isGoingToOppfolgingsplanOversikt) {
     path = `${path}/oppfoelgingsplaner`;
   } else if (isGoingToMoteoversikt) {
     path = `${path}/moteoversikt`;
   } else if (isGoingToAktivitetskrav) {
     path = `${path}/aktivitetskrav`;
+  } else if (isGoingToBehandlerdialog) {
+    path = `${path}/behandlerdialog`;
   }
   return fullNaisUrlDefault('syfomodiaperson', path);
 };


### PR DESCRIPTION
Vi hadde ingen direkte lenking til dialogmeldinger.

Den defaultet bare til personen, slik som for `Positiv Natthegre`
<img width="628" alt="image" src="https://github.com/navikt/syfooversikt/assets/37441744/d7794358-3a3a-4a44-9366-563b99096bbf">


For `Smekker Gapahuk`, som har flere oppgaver, blir det fortsatt slik, selv om filteret for meldinger er valgt. Kanskje en veileder-win å fikse på sikt?
<img width="698" alt="image" src="https://github.com/navikt/syfooversikt/assets/37441744/dfad18b2-1448-47b8-877d-658f2fb4655e">
