### PR TITLE
[IS-1577] Allow veileder to filter on dnr-dates as well

### DIFF
--- a/mock/data/personInfoMock.ts
+++ b/mock/data/personInfoMock.ts
@@ -12,7 +12,7 @@ export const personInfoMock: PersonregisterData[] = [
     skjermingskode: 'INGEN',
   },
   {
-    fnr: '99999933333',
+    fnr: '59999933333',
     navn: 'Korrupt Bolle',
     skjermingskode: 'DISKRESJONSMERKET',
   },

--- a/mock/data/personoversiktEnhetMock.ts
+++ b/mock/data/personoversiktEnhetMock.ts
@@ -38,7 +38,7 @@ export const personoversiktEnhetMock: PersonOversiktStatusDTO[] = [
     behandlerdialogUbehandlet: true,
   },
   {
-    fnr: '99999933333',
+    fnr: '59999933333',
     navn: '',
     enhet: '0316',
     veilederIdent: 'Z101010',

--- a/src/components/filters/BirthDateFilter.tsx
+++ b/src/components/filters/BirthDateFilter.tsx
@@ -3,7 +3,7 @@ import Select from 'react-select';
 import { ValueType } from 'react-select/src/types';
 import { FilterTitle } from '../FilterTitle';
 
-const allDates = new Array(31)
+const allDates = new Array(71)
   .fill(1)
   .map((currentNumber, index) => currentNumber + index);
 

--- a/test/data/fellesTestdata.ts
+++ b/test/data/fellesTestdata.ts
@@ -13,7 +13,7 @@ const enhetId = '0316';
 export const testdata = {
   fnr1: '01999911111',
   fnr2: '99999922222',
-  fnr3: '99999933333',
+  fnr3: '59999933333',
   fnr4: '99999944444',
   navn1: 'Et navn',
   navn2: 'Et annet navn',


### PR DESCRIPTION
Vi utvider lista fra 31 til 71 datoer, ettersom at NAV Oppfølging Utland ønsker å filtrere på d-nr i oversikten også. D-nr er som et vanlig fnr, men de to første sifferene har +40 i verdi.

<img width="836" alt="image" src="https://github.com/navikt/syfooversikt/assets/37441744/cf6fd18d-b5c6-4f07-9a0b-e5c4f4943a7c">
