### PR TITLE
IS-1639: Add new filter for vurder stans

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,7 @@
+### Hva har blitt lagt til✨🌈
+
+Hva er nytt / hva har blitt fikset?
+
+### Screenshots 📸✨
+
+Hvis ny synlig feature – ta screenshot!

--- a/mock/data/personoversiktEnhetMock.ts
+++ b/mock/data/personoversiktEnhetMock.ts
@@ -20,6 +20,7 @@ export const personoversiktEnhetMock: PersonOversiktStatusDTO[] = [
     motestatus: undefined,
     dialogmotesvarUbehandlet: false,
     behandlerdialogUbehandlet: false,
+    aktivitetskravVurderStansUbehandlet: false,
   },
   {
     fnr: '99999922222',
@@ -36,6 +37,24 @@ export const personoversiktEnhetMock: PersonOversiktStatusDTO[] = [
     motestatus: undefined,
     dialogmotesvarUbehandlet: false,
     behandlerdialogUbehandlet: true,
+    aktivitetskravVurderStansUbehandlet: false,
+  },
+  {
+    fnr: '99999922220',
+    navn: 'Ola Forhåndsvarselsen',
+    enhet: '0316',
+    veilederIdent: null,
+    motebehovUbehandlet: true,
+    aktivitetskrav: AktivitetskravStatus.FORHANDSVARSEL,
+    aktivitetskravActive: true,
+    aktivitetskravSistVurdert: new Date('2022-12-01T10:12:05.913826'),
+    aktivitetskravVurderingFrist: null,
+    oppfolgingsplanLPSBistandUbehandlet: null,
+    dialogmotekandidat: undefined,
+    motestatus: undefined,
+    dialogmotesvarUbehandlet: false,
+    behandlerdialogUbehandlet: false,
+    aktivitetskravVurderStansUbehandlet: true,
   },
   {
     fnr: '59999933333',
@@ -52,6 +71,7 @@ export const personoversiktEnhetMock: PersonOversiktStatusDTO[] = [
     motestatus: undefined,
     dialogmotesvarUbehandlet: false,
     behandlerdialogUbehandlet: false,
+    aktivitetskravVurderStansUbehandlet: false,
     latestOppfolgingstilfelle: {
       oppfolgingstilfelleStart: new Date('2022-10-25'),
       oppfolgingstilfelleEnd: new Date('2022-12-31'),
@@ -90,6 +110,7 @@ export const personoversiktEnhetMock: PersonOversiktStatusDTO[] = [
     aktivitetskravVurderingFrist: null,
     dialogmotesvarUbehandlet: false,
     behandlerdialogUbehandlet: false,
+    aktivitetskravVurderStansUbehandlet: false,
     latestOppfolgingstilfelle: {
       oppfolgingstilfelleStart: new Date('2022-08-03'),
       oppfolgingstilfelleEnd: new Date('2022-12-31'),
@@ -124,6 +145,7 @@ export const personoversiktEnhetMock: PersonOversiktStatusDTO[] = [
     aktivitetskravSistVurdert: new Date('2022-12-01T10:12:05.913826'),
     aktivitetskravVurderingFrist: new Date('2023-04-01'),
     behandlerdialogUbehandlet: false,
+    aktivitetskravVurderStansUbehandlet: false,
     latestOppfolgingstilfelle: {
       oppfolgingstilfelleStart: new Date('2022-08-01'),
       oppfolgingstilfelleEnd: new Date('2022-12-31'),
@@ -154,6 +176,7 @@ export const personoversiktEnhetMock: PersonOversiktStatusDTO[] = [
     aktivitetskravSistVurdert: new Date('1984-01-19T10:12:05.913826'),
     aktivitetskravVurderingFrist: null,
     behandlerdialogUbehandlet: false,
+    aktivitetskravVurderStansUbehandlet: false,
     latestOppfolgingstilfelle: {
       oppfolgingstilfelleStart: new Date('2022-01-01'),
       oppfolgingstilfelleEnd: new Date('2022-12-31'),
@@ -180,6 +203,7 @@ export const personoversiktEnhetMock: PersonOversiktStatusDTO[] = [
     aktivitetskravSistVurdert: new Date('2022-12-01T10:12:05.913826'),
     aktivitetskravVurderingFrist: null,
     behandlerdialogUbehandlet: false,
+    aktivitetskravVurderStansUbehandlet: false,
     latestOppfolgingstilfelle: {
       oppfolgingstilfelleStart: new Date('2022-01-01'),
       oppfolgingstilfelleEnd: new Date('2022-12-31'),
@@ -206,6 +230,7 @@ export const personoversiktEnhetMock: PersonOversiktStatusDTO[] = [
     aktivitetskravSistVurdert: new Date('2022-12-01T10:12:05.913826'),
     aktivitetskravVurderingFrist: null,
     behandlerdialogUbehandlet: false,
+    aktivitetskravVurderStansUbehandlet: false,
     latestOppfolgingstilfelle: {
       oppfolgingstilfelleStart: new Date('2022-01-01'),
       oppfolgingstilfelleEnd: new Date('2022-12-31'),
@@ -232,6 +257,7 @@ export const personoversiktEnhetMock: PersonOversiktStatusDTO[] = [
     aktivitetskravSistVurdert: new Date('2022-12-01T10:12:05.913826'),
     aktivitetskravVurderingFrist: null,
     behandlerdialogUbehandlet: false,
+    aktivitetskravVurderStansUbehandlet: false,
     latestOppfolgingstilfelle: {
       oppfolgingstilfelleStart: new Date('2022-05-01'),
       oppfolgingstilfelleEnd: new Date('2022-12-31'),
@@ -258,6 +284,7 @@ export const personoversiktEnhetMock: PersonOversiktStatusDTO[] = [
     aktivitetskravSistVurdert: new Date('2022-12-01T10:12:05.913826'),
     aktivitetskravVurderingFrist: null,
     behandlerdialogUbehandlet: false,
+    aktivitetskravVurderStansUbehandlet: false,
     latestOppfolgingstilfelle: {
       oppfolgingstilfelleStart: new Date('2022-10-01'),
       oppfolgingstilfelleEnd: new Date('2022-12-31'),
@@ -288,6 +315,7 @@ export const personoversiktEnhetMock: PersonOversiktStatusDTO[] = [
     aktivitetskravSistVurdert: new Date('2022-12-01T10:12:05.913826'),
     aktivitetskravVurderingFrist: null,
     behandlerdialogUbehandlet: false,
+    aktivitetskravVurderStansUbehandlet: false,
     latestOppfolgingstilfelle: {
       oppfolgingstilfelleStart: new Date('2022-01-01'),
       oppfolgingstilfelleEnd: new Date('2022-12-31'),
@@ -314,6 +342,7 @@ export const personoversiktEnhetMock: PersonOversiktStatusDTO[] = [
     aktivitetskravSistVurdert: new Date('2022-12-01T10:12:05.913826'),
     aktivitetskravVurderingFrist: null,
     behandlerdialogUbehandlet: false,
+    aktivitetskravVurderStansUbehandlet: false,
     latestOppfolgingstilfelle: {
       oppfolgingstilfelleStart: new Date('2022-01-01'),
       oppfolgingstilfelleEnd: new Date('2022-12-31'),
@@ -341,6 +370,7 @@ export const personoversiktEnhetMock: PersonOversiktStatusDTO[] = [
     aktivitetskravSistVurdert: new Date('2022-12-01T10:12:05.913826'),
     aktivitetskravVurderingFrist: null,
     behandlerdialogUbehandlet: false,
+    aktivitetskravVurderStansUbehandlet: false,
   },
   {
     fnr: '99999966673',
@@ -357,6 +387,7 @@ export const personoversiktEnhetMock: PersonOversiktStatusDTO[] = [
     aktivitetskravSistVurdert: new Date('2022-10-01T10:12:05.913826'),
     aktivitetskravVurderingFrist: null,
     behandlerdialogUbehandlet: false,
+    aktivitetskravVurderStansUbehandlet: false,
     latestOppfolgingstilfelle: {
       oppfolgingstilfelleStart: new Date('2022-01-01'),
       oppfolgingstilfelleEnd: new Date('2022-12-31'),
@@ -383,6 +414,7 @@ export const personoversiktEnhetMock: PersonOversiktStatusDTO[] = [
     aktivitetskravSistVurdert: new Date('2022-12-01T10:12:05.913826'),
     aktivitetskravVurderingFrist: null,
     behandlerdialogUbehandlet: false,
+    aktivitetskravVurderStansUbehandlet: false,
     latestOppfolgingstilfelle: {
       oppfolgingstilfelleStart: new Date('2022-01-01'),
       oppfolgingstilfelleEnd: new Date('2022-12-31'),
@@ -409,6 +441,7 @@ export const personoversiktEnhetMock: PersonOversiktStatusDTO[] = [
     aktivitetskravSistVurdert: new Date('2020-12-01T10:12:05.913826'),
     aktivitetskravVurderingFrist: null,
     behandlerdialogUbehandlet: false,
+    aktivitetskravVurderStansUbehandlet: false,
     latestOppfolgingstilfelle: {
       oppfolgingstilfelleStart: new Date('2022-01-01'),
       oppfolgingstilfelleEnd: new Date('2022-12-31'),
@@ -435,6 +468,7 @@ export const personoversiktEnhetMock: PersonOversiktStatusDTO[] = [
     aktivitetskravVurderingFrist: null,
     dialogmotesvarUbehandlet: false,
     behandlerdialogUbehandlet: false,
+    aktivitetskravVurderStansUbehandlet: false,
     latestOppfolgingstilfelle: {
       oppfolgingstilfelleStart: new Date('2022-01-01'),
       oppfolgingstilfelleEnd: new Date('2022-12-31'),
@@ -461,6 +495,7 @@ export const personoversiktEnhetMock: PersonOversiktStatusDTO[] = [
     aktivitetskravVurderingFrist: null,
     dialogmotesvarUbehandlet: false,
     behandlerdialogUbehandlet: false,
+    aktivitetskravVurderStansUbehandlet: false,
     latestOppfolgingstilfelle: {
       oppfolgingstilfelleStart: new Date('2022-01-01'),
       oppfolgingstilfelleEnd: new Date('2022-12-31'),
@@ -487,6 +522,7 @@ export const personoversiktEnhetMock: PersonOversiktStatusDTO[] = [
     aktivitetskravVurderingFrist: null,
     dialogmotesvarUbehandlet: false,
     behandlerdialogUbehandlet: false,
+    aktivitetskravVurderStansUbehandlet: false,
     latestOppfolgingstilfelle: {
       oppfolgingstilfelleStart: new Date('2022-01-01'),
       oppfolgingstilfelleEnd: new Date('2022-12-31'),
@@ -513,6 +549,7 @@ export const personoversiktEnhetMock: PersonOversiktStatusDTO[] = [
     aktivitetskravVurderingFrist: null,
     dialogmotesvarUbehandlet: false,
     behandlerdialogUbehandlet: false,
+    aktivitetskravVurderStansUbehandlet: false,
     latestOppfolgingstilfelle: {
       oppfolgingstilfelleStart: new Date('2022-01-01'),
       oppfolgingstilfelleEnd: new Date('2022-12-31'),

--- a/mock/data/personoversiktEnhetMock.ts
+++ b/mock/data/personoversiktEnhetMock.ts
@@ -46,7 +46,7 @@ export const personoversiktEnhetMock: PersonOversiktStatusDTO[] = [
     veilederIdent: null,
     motebehovUbehandlet: true,
     aktivitetskrav: AktivitetskravStatus.FORHANDSVARSEL,
-    aktivitetskravActive: true,
+    aktivitetskravActive: false,
     aktivitetskravSistVurdert: new Date('2022-12-01T10:12:05.913826'),
     aktivitetskravVurderingFrist: null,
     oppfolgingsplanLPSBistandUbehandlet: null,

--- a/mock/mockUtils.ts
+++ b/mock/mockUtils.ts
@@ -74,6 +74,7 @@ export const generatePersonoversiktEnhetFromPersons = (
       motestatus: undefined,
       dialogmotesvarUbehandlet: false,
       behandlerdialogUbehandlet: false,
+      aktivitetskravVurderStansUbehandlet: false,
     };
   });
 };

--- a/server/unleash.ts
+++ b/server/unleash.ts
@@ -42,5 +42,9 @@ export const getToggles = (veilederId: any, enhetId: any) => {
       'isMotebehovTilbakemeldingEnabled',
       context
     ),
+    isSendingAvForhandsvarselEnabled: unleash.isEnabled(
+      'isSendingAvForhandsvarselEnabled',
+      context
+    ),
   };
 };

--- a/src/api/types/personoversiktTypes.ts
+++ b/src/api/types/personoversiktTypes.ts
@@ -35,6 +35,7 @@ export interface PersonOversiktStatusDTO {
   aktivitetskravActive: boolean;
   aktivitetskravVurderingFrist: Date | null;
   behandlerdialogUbehandlet: boolean;
+  aktivitetskravVurderStansUbehandlet: boolean;
 }
 
 export interface OppfolgingstilfelleDTO {

--- a/src/api/types/personregisterTypes.ts
+++ b/src/api/types/personregisterTypes.ts
@@ -29,6 +29,7 @@ export interface PersonData {
   aktivitetskravActive: boolean;
   aktivitetskravVurderingFrist: Date | null;
   harBehandlerdialogUbehandlet: boolean;
+  harAktivitetskravVurderStansUbehandlet: boolean;
 }
 
 export interface PersonregisterState {

--- a/src/context/filters/filterContextState.ts
+++ b/src/context/filters/filterContextState.ts
@@ -6,6 +6,7 @@ export interface HendelseTypeFilters {
   dialogmotesvar: boolean;
   aktivitetskrav: boolean;
   behandlerdialog: boolean;
+  aktivitetskravVurderStans: boolean;
 }
 
 export interface FilterState {
@@ -31,5 +32,6 @@ export const filterInitialState: FilterState = {
     dialogmotesvar: false,
     aktivitetskrav: false,
     behandlerdialog: false,
+    aktivitetskravVurderStans: false,
   },
 };

--- a/src/data/personoversiktHooks.ts
+++ b/src/data/personoversiktHooks.ts
@@ -16,7 +16,8 @@ const isUbehandlet = (personOversiktStatus: PersonOversiktStatusDTO) => {
     personOversiktStatus.oppfolgingsplanLPSBistandUbehandlet ||
     personOversiktStatus.dialogmotesvarUbehandlet ||
     personOversiktStatus.dialogmotekandidat ||
-    personOversiktStatus.behandlerdialogUbehandlet
+    personOversiktStatus.behandlerdialogUbehandlet ||
+    personOversiktStatus.aktivitetskravVurderStansUbehandlet
   );
 };
 

--- a/src/data/unleash/types/unleash_types.ts
+++ b/src/data/unleash/types/unleash_types.ts
@@ -5,8 +5,10 @@ export type Toggles = {
 // See toggles: https://teamsykefravr-unleash-web.nav.cloud.nais.io/features
 export enum ToggleNames {
   isMotebehovTilbakemeldingEnabled = 'isMotebehovTilbakemeldingEnabled',
+  isSendingAvForhandsvarselEnabled = 'isSendingAvForhandsvarselEnabled',
 }
 
 export const defaultToggles: Toggles = {
   isMotebehovTilbakemeldingEnabled: false,
+  isSendingAvForhandsvarselEnabled: false,
 };

--- a/src/utils/hendelseFilteringUtils.tsx
+++ b/src/utils/hendelseFilteringUtils.tsx
@@ -100,7 +100,9 @@ export const filterOnPersonregister = (
       (!filter.ufordeltBruker || !personData.tildeltVeilederIdent) &&
       (!filter.dialogmotesvar || personData.harDialogmotesvar) &&
       (!filter.aktivitetskrav || personData.aktivitetskravActive) &&
-      (!filter.behandlerdialog || personData.harBehandlerdialogUbehandlet)
+      (!filter.behandlerdialog || personData.harBehandlerdialogUbehandlet) &&
+      (!filter.aktivitetskravVurderStans ||
+        personData.harAktivitetskravVurderStansUbehandlet)
     );
   });
 

--- a/src/utils/lenkeUtil.tsx
+++ b/src/utils/lenkeUtil.tsx
@@ -17,7 +17,9 @@ export const lenkeTilModia = (personData: PersonData) => {
     personData.dialogmotekandidat;
   const isGoingToOppfolgingsplanOversikt =
     personData.harOppfolgingsplanLPSBistandUbehandlet;
-  const isGoingToAktivitetskrav = personData.aktivitetskravActive;
+  const isGoingToAktivitetskrav =
+    personData.aktivitetskravActive ||
+    personData.harAktivitetskravVurderStansUbehandlet;
   const isGoingToBehandlerdialog = personData.harBehandlerdialogUbehandlet;
 
   if (isGoingToOppfolgingsplanOversikt) {

--- a/src/utils/toPersondata.ts
+++ b/src/utils/toPersondata.ts
@@ -32,6 +32,8 @@ export const toPersonData = (
       aktivitetskravActive: person.aktivitetskravActive,
       aktivitetskravVurderingFrist: person.aktivitetskravVurderingFrist,
       harBehandlerdialogUbehandlet: person.behandlerdialogUbehandlet,
+      harAktivitetskravVurderStansUbehandlet:
+        person.aktivitetskravVurderStansUbehandlet,
     };
   });
 

--- a/test/components/Personrad.test.tsx
+++ b/test/components/Personrad.test.tsx
@@ -55,6 +55,7 @@ const defaultPersonData: PersonData = {
   aktivitetskravActive: false,
   aktivitetskravVurderingFrist: null,
   harBehandlerdialogUbehandlet: false,
+  harAktivitetskravVurderStansUbehandlet: false,
 };
 const personDataAktivitetskravAvventUtenFrist: PersonData = {
   ...defaultPersonData,

--- a/test/components/Sokeresultat.test.tsx
+++ b/test/components/Sokeresultat.test.tsx
@@ -63,6 +63,7 @@ describe('Sokeresultat', () => {
         dialogmotesvar: true,
         aktivitetskrav: false,
         behandlerdialog: false,
+        aktivitetskravVurderStans: false,
       },
     };
 

--- a/test/data/fellesTestdata.ts
+++ b/test/data/fellesTestdata.ts
@@ -69,6 +69,7 @@ export const personoversikt: PersonOversiktStatusDTO[] = [
     aktivitetskravActive: false,
     aktivitetskravVurderingFrist: null,
     behandlerdialogUbehandlet: false,
+    aktivitetskravVurderStansUbehandlet: false,
   },
   {
     fnr: testdata.fnr4,
@@ -85,6 +86,7 @@ export const personoversikt: PersonOversiktStatusDTO[] = [
     aktivitetskravActive: false,
     aktivitetskravVurderingFrist: null,
     behandlerdialogUbehandlet: false,
+    aktivitetskravVurderStansUbehandlet: false,
   },
 ];
 

--- a/test/utils/hendelseFilteringUtilsTest.ts
+++ b/test/utils/hendelseFilteringUtilsTest.ts
@@ -28,6 +28,7 @@ const createPersonDataWithName = (name: string): PersonData => {
     aktivitetskravActive: false,
     aktivitetskravVurderingFrist: null,
     harBehandlerdialogUbehandlet: false,
+    harAktivitetskravVurderStansUbehandlet: false,
   };
 };
 
@@ -39,6 +40,7 @@ const defaulthendelseFilter = {
   dialogmotesvar: false,
   aktivitetskrav: false,
   behandlerdialog: false,
+  aktivitetskravVurderStans: false,
 };
 
 describe('hendelseFilteringUtils', () => {


### PR DESCRIPTION
### Hva har blitt lagt til✨🌈
Legger til en ny hendelse i oversikten, som ligger bak featuretoggle for forhåndsvarselet. På den måten vil veiledere som har tilgang til å sende forhåndsvarsel, også få opp den nye hendelsen blant filterene i oversikten. Hvis veileder klikker på personer som har vurder-stans-oppgaven aktivt, vil de bli sendt til `/aktivitetskrav`-siden i syfomodiaperson.

Per nå tror jeg de personene også vil ligge under aktivitetskrav-filteret, ettersom de har et aktivt aktivitetskrav 🤔 Så mulig det er noen forbedringer her på sikt!

### Screenshots 📸✨
<img width="360" alt="image" src="https://github.com/navikt/syfooversikt/assets/37441744/7b868c9f-1bba-4e0c-bb0a-ddd8b09a08bc">
