### PR TITLE
IS-1766: Make sure all dates are Date

### DIFF
--- a/src/utils/dateUtils.ts
+++ b/src/utils/dateUtils.ts
@@ -1,11 +1,17 @@
 import dayjs from 'dayjs';
 
-export const getEarliestDate = (date1: Date, date2: Date): Date => {
-  return date1 < date2 ? date1 : date2;
+export const getEarliestDate = (
+  date1: Date | string,
+  date2: Date | string
+): Date => {
+  return new Date(date1) < new Date(date2) ? new Date(date1) : new Date(date2);
 };
 
-export const getWeeksBetween = (date1: Date, date2: Date): number => {
-  return Math.abs(dayjs(date1).diff(date2, 'week'));
+export const getWeeksBetween = (
+  date1: Date | string,
+  date2: Date | string
+): number => {
+  return Math.abs(dayjs(date1).diff(dayjs(date2), 'week'));
 };
 
 export const toReadableDate = (dateArg: Date | null): string => {

--- a/test/utils/dateUtils.test.ts
+++ b/test/utils/dateUtils.test.ts
@@ -8,14 +8,16 @@ import {
 describe('dateUtils', () => {
   describe('Calculations', () => {
     it('Will calculate number of weeks between two dates', () => {
-      const date1 = new Date('2022-10-01');
-      const date2 = new Date('2022-10-15');
-      expect(getWeeksBetween(date1, date2)).to.equal(2);
+      const date1 = new Date('2022-03-16');
+      const date2 = getEarliestDate('2022-07-31', new Date());
+      expect(getWeeksBetween(date1, date2)).to.equal(19);
     });
     it('Will calculate earliest date', () => {
-      const earliesDate = new Date('2023-01-01');
+      const earliestDate = new Date('2023-01-01');
       const latestDate = new Date('2023-02-02');
-      expect(getEarliestDate(earliesDate, latestDate)).to.equal(earliesDate);
+      expect(getEarliestDate(earliestDate, latestDate).getTime()).to.equal(
+        earliestDate.getTime()
+      );
     });
   });
   describe('readable date', () => {


### PR DESCRIPTION
### Hva har blitt lagt til✨🌈
Dette ble fortsatt feil i oversikten ifølge innmelder av jira-saken. Mistenker at Localdate fra APIet ikke blir gjort om til en Date-type i serialiseringen i DTOet, og derfor slenger vi på new Date() rundt alt her slik at sammenligning av datoer blir riktig.