### PR TITLE
IS-1942: Add event for filter usage

### DIFF
--- a/src/components/filters/FristFilter.tsx
+++ b/src/components/filters/FristFilter.tsx
@@ -1,6 +1,8 @@
 import { CheckboxGroup, Checkbox } from '@navikt/ds-react';
 import { FristFilterOption } from '@/utils/hendelseFilteringUtils';
 import React from 'react';
+import * as Amplitude from '@/utils/amplitude';
+import { EventType } from '@/utils/amplitude';
 
 const texts = {
   legend: 'Frist',
@@ -15,11 +17,25 @@ interface Props {
   onChange(value: FristFilterOption[]): void;
 }
 
+function logOptionSelectedEvent(option: FristFilterOption[]) {
+  Amplitude.logEvent({
+    type: EventType.OptionSelected,
+    data: {
+      url: window.location.href,
+      tekst: 'Fristfilter endret',
+      option: option.toString(),
+    },
+  });
+}
+
 export const FristFilter = ({ onChange }: Props) => {
   return (
     <CheckboxGroup
       legend={texts.legend}
-      onChange={(val: FristFilterOption[]) => onChange(val)}
+      onChange={(val: FristFilterOption[]) => {
+        onChange(val);
+        logOptionSelectedEvent(val);
+      }}
       size="small"
     >
       <Checkbox value={FristFilterOption.Past}>{texts.option.past}</Checkbox>


### PR DESCRIPTION
### Hva har blitt lagt til✨🌈
- Legger til event som tracker når bruker endrer frist filteret.
- Vi er interessert i å se hvilke perioder de bruker filteret for og hvor stor andel av de som besøker siden bruker filteret.

### Annet
- Noe jeg lurer litt på her er hvordan vi skal få tracket personer som allerede har filtre aktivert og som ligger i cache 🤔 Rop ut hvis du har noen idéer. Det høres ut som noe vi må logge når man renderer siden…

