### PR TITLE
IS-2360: Vis friskmelding til arbeidsformidling vedtak-fom i frist-kolonnen og inkluder i filtrering og sortering

### DIFF
--- a/src/api/types/personregisterTypes.ts
+++ b/src/api/types/personregisterTypes.ts
@@ -34,7 +34,7 @@ export interface PersonData {
   harOppfolgingsoppgave: boolean;
   oppfolgingsoppgaveFrist: Date | null;
   behandlerBerOmBistandUbehandlet: boolean;
-  harFriskmeldingTilArbeidsformidling: boolean;
+  friskmeldingTilArbeidsformidlingFom: Date | null;
 }
 
 export interface PersonregisterState {

--- a/src/components/FristColumn.tsx
+++ b/src/components/FristColumn.tsx
@@ -10,8 +10,8 @@ import { AktivitetskravStatus } from '@/api/types/personoversiktTypes';
 import { Tooltip } from '@navikt/ds-react';
 
 const texts = {
-  tooltipAvventer: 'Avventer',
-  tooltipOppfolgingsoppgave: 'Oppfølgingsoppgave',
+  tooltipAvventer: 'Avventer til',
+  tooltipOppfolgingsoppgave: 'Oppfølgingsoppgave frist',
   tooltipFriskmeldingTilArbeidsformidling: '§8-5 f.o.m.',
 };
 

--- a/src/components/FristColumn.tsx
+++ b/src/components/FristColumn.tsx
@@ -1,6 +1,10 @@
 import { PersonData } from '@/api/types/personregisterTypes';
 import { toReadableDate } from '@/utils/dateUtils';
-import { FileTextIcon, HourglassTopFilledIcon } from '@navikt/aksel-icons';
+import {
+  FileTextIcon,
+  HourglassTopFilledIcon,
+  HeadHeartIcon,
+} from '@navikt/aksel-icons';
 import React, { ReactElement } from 'react';
 import { AktivitetskravStatus } from '@/api/types/personoversiktTypes';
 import { Tooltip } from '@navikt/ds-react';
@@ -8,6 +12,7 @@ import { Tooltip } from '@navikt/ds-react';
 const texts = {
   tooltipAvventer: 'Avventer',
   tooltipOppfolgingsoppgave: 'Oppfølgingsoppgave',
+  tooltipFriskmeldingTilArbeidsformidling: '§8-5',
 };
 
 interface FristColumnProps {
@@ -29,6 +34,7 @@ export const FristColumn = ({ personData }: FristColumnProps) => {
     aktivitetskrav,
     aktivitetskravVurderingFrist,
     oppfolgingsoppgaveFrist,
+    friskmeldingTilArbeidsformidlingFom,
   } = personData;
   const frister: Frist[] = [];
   if (
@@ -49,14 +55,22 @@ export const FristColumn = ({ personData }: FristColumnProps) => {
     });
   }
 
+  if (friskmeldingTilArbeidsformidlingFom) {
+    frister.push({
+      icon: () => <HeadHeartIcon aria-hidden fontSize="1.5rem" />,
+      date: friskmeldingTilArbeidsformidlingFom,
+      tooltip: texts.tooltipFriskmeldingTilArbeidsformidling,
+    });
+  }
+
   return (
     <>
       {frister.sort(byFristAsc).map(({ date, icon, tooltip }, index) => (
-        <div key={index} className="flex flex-wrap">
+        <div key={index} className="flex flex-wrap items-center">
           <Tooltip content={tooltip} arrow={false}>
             {icon()}
           </Tooltip>
-          {toReadableDate(date)}
+          <div>{toReadableDate(date)}</div>
         </div>
       ))}
     </>

--- a/src/components/FristColumn.tsx
+++ b/src/components/FristColumn.tsx
@@ -12,7 +12,7 @@ import { Tooltip } from '@navikt/ds-react';
 const texts = {
   tooltipAvventer: 'Avventer',
   tooltipOppfolgingsoppgave: 'Oppfølgingsoppgave',
-  tooltipFriskmeldingTilArbeidsformidling: '§8-5',
+  tooltipFriskmeldingTilArbeidsformidling: '§8-5 f.o.m.',
 };
 
 interface FristColumnProps {

--- a/src/components/FristColumn.tsx
+++ b/src/components/FristColumn.tsx
@@ -3,7 +3,7 @@ import { toReadableDate } from '@/utils/dateUtils';
 import {
   FileTextIcon,
   HourglassTopFilledIcon,
-  HeadHeartIcon,
+  BriefcaseIcon,
 } from '@navikt/aksel-icons';
 import React, { ReactElement } from 'react';
 import { AktivitetskravStatus } from '@/api/types/personoversiktTypes';
@@ -57,7 +57,7 @@ export const FristColumn = ({ personData }: FristColumnProps) => {
 
   if (friskmeldingTilArbeidsformidlingFom) {
     frister.push({
-      icon: () => <HeadHeartIcon aria-hidden fontSize="1.5rem" />,
+      icon: () => <BriefcaseIcon aria-hidden fontSize="1.5rem" />,
       date: friskmeldingTilArbeidsformidlingFom,
       tooltip: texts.tooltipFriskmeldingTilArbeidsformidling,
     });

--- a/src/components/Sorteringsrad.tsx
+++ b/src/components/Sorteringsrad.tsx
@@ -15,7 +15,7 @@ const tekster = {
   overskriftVeileder: 'Veileder',
   virksomhet: 'Virksomhet',
   varighetSykefravar: 'Sykefravær',
-  frist: 'Frist',
+  frist: 'Frist/dato',
 };
 
 export const GrayChevron = styled(Chevron)`

--- a/src/utils/dateUtils.ts
+++ b/src/utils/dateUtils.ts
@@ -1,4 +1,7 @@
 import dayjs from 'dayjs';
+import minMax from 'dayjs/plugin/minMax';
+
+dayjs.extend(minMax);
 
 export const toReadableDate = (dateArg: Date | null): string => {
   if (!dateArg) {
@@ -35,3 +38,13 @@ export function isFuture(compareDate: Date): boolean {
   const date = new Date(compareDate);
   return currentDate < date;
 }
+
+export const earliestDate = (dateArray: Date[]): Date | null =>
+  dateArray.length > 0
+    ? dayjs.min(dateArray.map((date: Date) => dayjs(date))).toDate()
+    : null;
+
+export const latestDate = (dateArray: Date[]): Date | null =>
+  dateArray.length > 0
+    ? dayjs.max(dateArray.map((date: Date) => dayjs(date))).toDate()
+    : null;

--- a/src/utils/hendelseFilteringUtils.tsx
+++ b/src/utils/hendelseFilteringUtils.tsx
@@ -97,22 +97,19 @@ export const filterOnFrist = (
     return personregister;
   }
   const filtered = Object.entries(personregister).filter(([, persondata]) => {
-    const aktivitetskravVurderingFrist =
-      persondata.aktivitetskravVurderingFrist;
-    const oppfolgingsoppgaveFrist = persondata.oppfolgingsoppgaveFrist;
-    if (
-      aktivitetskravVurderingFrist === null &&
-      oppfolgingsoppgaveFrist === null
-    ) {
+    const frister = [
+      persondata.aktivitetskravVurderingFrist,
+      persondata.oppfolgingsoppgaveFrist,
+      persondata.friskmeldingTilArbeidsformidlingFom,
+    ];
+
+    if (frister.every((frist) => frist === null)) {
       return true;
     }
-    const isOppfolgingsoppgaveVisible = oppfolgingsoppgaveFrist
-      ? isInFristFilter(selectedFristFilters, oppfolgingsoppgaveFrist)
-      : false;
-    const isAktivitetskravVisible = aktivitetskravVurderingFrist
-      ? isInFristFilter(selectedFristFilters, aktivitetskravVurderingFrist)
-      : false;
-    return isOppfolgingsoppgaveVisible || isAktivitetskravVisible;
+
+    return frister.some(
+      (frist) => frist && isInFristFilter(selectedFristFilters, frist)
+    );
   });
 
   return Object.fromEntries(filtered);
@@ -214,7 +211,7 @@ const matchesFilter = (
         !filters[key] || personData.harArbeidsuforhetVurderAvslagUbehandlet
       );
     case 'harFriskmeldingTilArbeidsformidling':
-      return !filters[key] || personData.harFriskmeldingTilArbeidsformidling;
+      return !filters[key] || !!personData.friskmeldingTilArbeidsformidlingFom;
   }
 };
 

--- a/src/utils/personDataUtil.ts
+++ b/src/utils/personDataUtil.ts
@@ -4,6 +4,7 @@ import {
   ReadableSkjermingskodeMap,
   Skjermingskode,
 } from '@/api/types/personregisterTypes';
+import { earliestDate, latestDate } from '@/utils/dateUtils';
 
 const readableSkjermingskoder: ReadableSkjermingskodeMap = {
   INGEN: 'ingen',
@@ -46,24 +47,22 @@ export const firstCompanyNameFromPersonData = (
   return companyNamesFromPersonData(p).shift();
 };
 
-export const getEarliestFrist = (personData: PersonData): Date | null => {
-  const { aktivitetskravVurderingFrist, oppfolgingsoppgaveFrist } = personData;
-  if (aktivitetskravVurderingFrist && oppfolgingsoppgaveFrist) {
-    return aktivitetskravVurderingFrist < oppfolgingsoppgaveFrist
-      ? aktivitetskravVurderingFrist
-      : oppfolgingsoppgaveFrist;
-  }
+const allFrister = (personData: PersonData): Date[] => {
+  return [
+    personData.aktivitetskravVurderingFrist,
+    personData.oppfolgingsoppgaveFrist,
+    personData.friskmeldingTilArbeidsformidlingFom,
+  ].filter((frist) => frist) as Date[];
+};
 
-  return aktivitetskravVurderingFrist || oppfolgingsoppgaveFrist || null;
+export const getEarliestFrist = (personData: PersonData): Date | null => {
+  const frister = allFrister(personData);
+
+  return earliestDate(frister);
 };
 
 export const getLatestFrist = (personData: PersonData): Date | null => {
-  const { aktivitetskravVurderingFrist, oppfolgingsoppgaveFrist } = personData;
-  if (aktivitetskravVurderingFrist && oppfolgingsoppgaveFrist) {
-    return aktivitetskravVurderingFrist < oppfolgingsoppgaveFrist
-      ? oppfolgingsoppgaveFrist
-      : aktivitetskravVurderingFrist;
-  }
+  const frister = allFrister(personData);
 
-  return aktivitetskravVurderingFrist || oppfolgingsoppgaveFrist || null;
+  return latestDate(frister);
 };

--- a/src/utils/toPersondata.ts
+++ b/src/utils/toPersondata.ts
@@ -4,7 +4,6 @@ import {
   PersonregisterState,
 } from '@/api/types/personregisterTypes';
 import { PersonOversiktStatusDTO } from '@/api/types/personoversiktTypes';
-import { isFuture } from '@/utils/dateUtils';
 
 export const toPersonData = (
   personoversiktData: PersonOversiktStatusDTO[],
@@ -40,10 +39,8 @@ export const toPersonData = (
       behandlerBerOmBistandUbehandlet: person.behandlerBerOmBistandUbehandlet,
       harArbeidsuforhetVurderAvslagUbehandlet:
         person.arbeidsuforhetVurderAvslagUbehandlet,
-      harFriskmeldingTilArbeidsformidling:
-        (person.friskmeldingTilArbeidsformidlingFom &&
-          isFuture(person.friskmeldingTilArbeidsformidlingFom)) ||
-        false,
+      friskmeldingTilArbeidsformidlingFom:
+        person.friskmeldingTilArbeidsformidlingFom,
     };
   });
 

--- a/test/components/Personrad.test.tsx
+++ b/test/components/Personrad.test.tsx
@@ -60,7 +60,7 @@ const defaultPersonData: PersonData = {
   oppfolgingsoppgaveFrist: null,
   behandlerBerOmBistandUbehandlet: false,
   harArbeidsuforhetVurderAvslagUbehandlet: false,
-  harFriskmeldingTilArbeidsformidling: false,
+  friskmeldingTilArbeidsformidlingFom: null,
 };
 const personDataAktivitetskravAvventUtenFrist: PersonData = {
   ...defaultPersonData,

--- a/test/utils/hendelseFilteringUtilsTest.ts
+++ b/test/utils/hendelseFilteringUtilsTest.ts
@@ -36,7 +36,7 @@ export const createPersonDataWithName = (name: string): PersonData => {
     oppfolgingsoppgaveFrist: null,
     behandlerBerOmBistandUbehandlet: false,
     harArbeidsuforhetVurderAvslagUbehandlet: false,
-    harFriskmeldingTilArbeidsformidling: false,
+    friskmeldingTilArbeidsformidlingFom: null,
   };
 };
 
@@ -546,6 +546,10 @@ describe('hendelseFilteringUtils', () => {
         aktivitetskravActive: true,
         aktivitetskravVurderingFrist: oneWeekFromToday,
       };
+      const friskmeldingTilArbeidsformidlingFomFuture: PersonData = {
+        ...createPersonDataWithName('Box Bulder'),
+        friskmeldingTilArbeidsformidlingFom: oneWeekFromToday,
+      };
 
       const personregister: PersonregisterState = {
         '16614407794': oppfolgingsOppgaveFristBeforeToday,
@@ -554,6 +558,7 @@ describe('hendelseFilteringUtils', () => {
         '16614407797': aktivitetskravVurderingFristToday,
         '16614407798': oppfolgingsOppgaveFristFuture,
         '16614407799': aktivitetskravVurderingFristFuture,
+        '16614407889': friskmeldingTilArbeidsformidlingFomFuture,
       };
 
       it('Only returns elements with frist dato before today', () => {
@@ -581,9 +586,10 @@ describe('hendelseFilteringUtils', () => {
           FristFilterOption.Future,
         ]);
 
-        expect(Object.keys(filteredPersonregister).length).to.equal(2);
+        expect(Object.keys(filteredPersonregister).length).to.equal(3);
         expect(Object.keys(filteredPersonregister)[0]).to.equal('16614407798');
         expect(Object.keys(filteredPersonregister)[1]).to.equal('16614407799');
+        expect(Object.keys(filteredPersonregister)[2]).to.equal('16614407889');
       });
     });
   });


### PR DESCRIPTION
Har i tillegg endret slik at vi viser personen i §8-5-filteret dersom fom-dato finnes (i stedet for sjekk på at den er i fremtiden), som vi har snakket om. Tanken er da at datoen skal nullstilles i oversikten når vedtaket ferdigbehandles (personen vil da forsvinne fra §8-5-filteret).

### Screenshots 📸✨

![image](https://github.com/navikt/syfooversikt/assets/79838644/314dded9-b3da-4f5e-8761-e6c8dd93994d)
