### PR TITLE
IS-2379: Add amplitude measurement for dropoff

### DIFF
--- a/src/components/flexjar/Flexjar.tsx
+++ b/src/components/flexjar/Flexjar.tsx
@@ -86,12 +86,35 @@ export const Flexjar = ({ side }: FlexjarProps) => {
     logPageView(side);
   }, [side]);
 
+  const toggleApen = () => {
+    if (isApen) {
+      setRadioValue(null);
+      setComboboxValue([]);
+      setFeedback('');
+    }
+    setIsApen(!isApen);
+  };
+
   const updateToggledOptions = (option: string, isSelected: boolean) => {
     if (isSelected) {
       setComboboxValue([...comboboxValue, option]);
     } else {
       setComboboxValue(comboboxValue.filter((val) => val !== option));
     }
+  };
+
+  const updateRadioValue = (value: RadioOption) => {
+    if (radioValue === null) {
+      Amplitude.logEvent({
+        type: EventType.OptionSelected,
+        data: {
+          option: value,
+          tekst: 'Radioknapp Flexjar Arena',
+          url: window.location.href,
+        },
+      });
+    }
+    setRadioValue(value);
   };
 
   const buildFeedbackString = (): string | undefined => {
@@ -141,7 +164,7 @@ export const Flexjar = ({ side }: FlexjarProps) => {
         variant="primary"
         iconPosition="right"
         icon={isApen ? <ChevronDownIcon /> : <ChevronUpIcon />}
-        onClick={() => setIsApen(!isApen)}
+        onClick={toggleApen}
         className="w-max"
       >
         {texts.apneKnapp}
@@ -167,7 +190,7 @@ export const Flexjar = ({ side }: FlexjarProps) => {
             <>
               <RadioGroup
                 legend={<Label>{texts.sporsmal}</Label>}
-                onChange={(e) => setRadioValue(e)}
+                onChange={(e) => updateRadioValue(e)}
                 description={texts.anonym}
                 size="small"
               >


### PR DESCRIPTION
### Hva har blitt lagt til✨🌈

Vi ønsker å måle om noen klikker på radioknappen, men ikke fullfører skjemaet. Dette kan vi gjøre ved å telle hvor mange som velger en radioknapp når verdien står på `null` (ikke valgt noe fra før), og sammenligne dette med hvor mange som fullfører og trykker `Send`.

Legger også til en slags _reset_ av skjemaet når man lukker knappen, ettersom at komponentene da ikke viste noe, men staten var fortsatt oppdatert. 
Eksempel: Klikker på `Ja`, lukker skjemaet, åpner skjemaet, ingen radioknapp er valgt - men staten er fortsatt `Ja`.
Det samme ble et problem for comboboxen; man kunne ha valgt ett element, lukket skjemaet, åpnet igjen og valgt et annet element. Da holder staten på begge elementene, så begge ville blitt sendt inn.
