### PR TITLE
IS-2379: Style combobox-list so results dont go outside screen.

### DIFF
--- a/src/components/flexjar/Flexjar.tsx
+++ b/src/components/flexjar/Flexjar.tsx
@@ -20,6 +20,7 @@ import { defaultErrorTexts } from '@/api/errors';
 import { StoreKey, useLocalStorageState } from '@/hooks/useLocalStorageState';
 import * as Amplitude from '@/utils/amplitude';
 import { EventType } from '@/utils/amplitude';
+import styled from 'styled-components';
 
 const texts = {
   apneKnapp: 'Vi ønsker å lære av deg',
@@ -53,6 +54,12 @@ const arenaOptions = [
   'Oppfølgingsoppgave',
   'Sjekke arbeidsforhold til sykmeldt',
 ];
+
+const StyledCombobox = styled(UNSAFE_Combobox)`
+  .navds-combobox__list {
+    max-height: 12rem;
+  }
+`;
 
 function logPageView(side: string) {
   Amplitude.logEvent({
@@ -124,7 +131,7 @@ export const Flexjar = ({ side }: FlexjarProps) => {
     let s = '';
     if (radioValue === RadioOption.JA) {
       s += `[${comboboxValue.join(', ')}]`;
-      s += feedback ? ' \n' + feedback : '';
+      s += feedback ? ' - ' + feedback : '';
     } else if (radioValue === RadioOption.NEI && feedback) {
       s += feedback;
     }
@@ -198,7 +205,7 @@ export const Flexjar = ({ side }: FlexjarProps) => {
                 <Radio value={RadioOption.NEI}>Nei</Radio>
               </RadioGroup>
               {radioValue === RadioOption.JA && (
-                <UNSAFE_Combobox
+                <StyledCombobox
                   label={texts.labelAlternativer}
                   options={arenaOptions}
                   isMultiSelect

--- a/src/containers/OversiktContainer.tsx
+++ b/src/containers/OversiktContainer.tsx
@@ -72,7 +72,9 @@ const OversiktContainer = ({ tabType }: Props): ReactElement => {
         <NotificationBar />
         <NavigationBar />
         <ContainerContent />
-        {showFlexjar && <Flexjar side={toReadableString(tabType)} />}
+        {showFlexjar && personoversiktQuery.isSuccess && (
+          <Flexjar side={toReadableString(tabType)} />
+        )}
       </div>
     </ErrorBoundary>
   );

--- a/test/components/flexjar/FlexjarTest.tsx
+++ b/test/components/flexjar/FlexjarTest.tsx
@@ -156,7 +156,7 @@ describe('Flexjar', () => {
       feedbackId: 'Test',
       app: 'syfooversikt',
       svar: 'Ja',
-      feedback: '[AEV, Tiltak]' + ' \n' + 'Tester innsending Ja',
+      feedback: '[AEV, Tiltak]' + ' - ' + 'Tester innsending Ja',
     };
     const sendFeedbackMutation = queryClient.getMutationCache().getAll()[0];
     expect(sendFeedbackMutation?.state.variables).to.deep.equal(


### PR DESCRIPTION
### Hva har blitt lagt til✨🌈

Egentlig 3 små endringer i én:
- Resultatene i comboboxen var lenger enn selve flexjar-panelet, så for å se nederste alternativ måtte man scrolle heeelt nederst i oversikten. Nå custom-styler vi lengden på denne, til å være ca 190px i stedet for 280px.
- Legger også til en liten endring på formatet vi sender til flexjar. Prøvde å sende `\n` før, men flexjar fjerner uansett denne i admin-panelet.
- Flexjar ble lastet inn før lista ble lastet inn, og siden lista bare er en spinner mens den laster, så hoppet flexjar-panelet opp midt på siden. Litt leit hvis det tar 10 sekunder å laste inn oversikten

### Screenshots 📸✨

<details>
<summary>Screenshot combobox</summary>
Før:
<img width="471" alt="image" src="https://github.com/navikt/syfooversikt/assets/37441744/072f5afe-3d15-4e4f-aefa-e20ae7195435">

Etter:
<img width="425" alt="image" src="https://github.com/navikt/syfooversikt/assets/37441744/4d5cb347-d1ab-4659-8505-1e79a355400d">
</details>

<details>
<summary>Screenshot innlasting</summary>
Før:

<img width="1059" alt="image" src="https://github.com/navikt/syfooversikt/assets/37441744/7bf62213-8907-4901-8f73-6a523db3c2c9">

Etter:
https://github.com/navikt/syfooversikt/assets/37441744/b4edaf56-93e3-492c-b4ed-818a26c91659


</details>