### PR TITLE
IS-2379: Fix overshadowing flexjar container

### DIFF
--- a/src/components/flexjar/Flexjar.tsx
+++ b/src/components/flexjar/Flexjar.tsx
@@ -166,7 +166,7 @@ export const Flexjar = ({ side }: FlexjarProps) => {
   };
 
   return (
-    <div className="flex flex-col sticky bottom-0 items-end z-[100]">
+    <div className="flex flex-col sticky bottom-0 self-end items-end z-[100]">
       <Button
         variant="primary"
         iconPosition="right"


### PR DESCRIPTION
### Hva har blitt lagt til✨🌈

Man kunne ikke trykke på ting som lå "bak" flexjar-raden, som strakk seg over hele skjermen. Nå passer vi på at containeren ikke går utover resten av skjermen.

<img width="986" alt="image" src="https://github.com/navikt/syfooversikt/assets/37441744/db233016-75d8-4a6c-b2e8-f1c53541a4eb">
 