### PR TITLE
IS-2440: Refactor VeilederColumn and TildelVeileder

### DIFF
--- a/src/components/VeilederColumn.tsx
+++ b/src/components/VeilederColumn.tsx
@@ -3,29 +3,30 @@ import { useVeiledereQuery } from '@/data/veiledereQueryHooks';
 import { PersonData } from '@/api/types/personregisterTypes';
 import { Tag } from '@navikt/ds-react';
 
-interface Props {
-  personData: PersonData;
-}
-
-export const VeilederColumn = ({ personData }: Props): ReactElement => {
+const VeilederName = ({ veilederIdent }: { veilederIdent: string }) => {
   const { data } = useVeiledereQuery();
-
-  const tildeltVeilederIdent = personData.tildeltVeilederIdent;
-
-  if (!tildeltVeilederIdent) {
-    return (
-      <Tag variant="info" size="small" className="p-1 rounded">
-        Ufordelt bruker
-      </Tag>
-    );
-  }
-
-  const tildeltVeileder = data?.find((v) => v.ident === tildeltVeilederIdent);
+  const tildeltVeileder = data?.find((v) => v.ident === veilederIdent);
   const veilederNavn = tildeltVeileder?.fornavn
     ? `${tildeltVeileder.etternavn}, ${tildeltVeileder.fornavn}`
-    : tildeltVeilederIdent;
+    : veilederIdent;
 
   return (
     <label className="overflow-hidden overflow-ellipsis">{veilederNavn}</label>
+  );
+};
+
+export const VeilederColumn = ({
+  personData,
+}: {
+  personData: PersonData;
+}): ReactElement => {
+  const tildeltVeilederIdent = personData.tildeltVeilederIdent;
+
+  return tildeltVeilederIdent ? (
+    <VeilederName veilederIdent={tildeltVeilederIdent} />
+  ) : (
+    <Tag variant="info" size="small" className="p-1 rounded">
+      Ufordelt bruker
+    </Tag>
   );
 };

--- a/src/components/toolbar/AssignVeileder/TildelVeileder.tsx
+++ b/src/components/toolbar/AssignVeileder/TildelVeileder.tsx
@@ -1,15 +1,10 @@
 import React, { ChangeEvent, ReactElement, useEffect, useState } from 'react';
-import {
-  assignUsersToSelectedVeileder,
-  filterVeiledereOnInput,
-  hasNoCheckedPersoner,
-} from '@/utils/assignVeilederUtils';
+import { filterVeiledereOnInput } from '@/utils/assignVeilederUtils';
 import { sortVeiledereAlphabeticallyWithGivenVeilederFirst } from '@/utils/veiledereUtils';
 import { VeilederDTO } from '@/api/types/veiledereTypes';
 import OpenDropdownButton from '../OpenDropdownButton/OpenDropdownButton';
 import { Dropdown } from '../Dropdown/Dropdown';
 import { DropdownButtonTexts } from '../Dropdown/DropdownButtons';
-import { ToolbarWrapperProps } from '../ToolbarWrapper';
 import {
   useAktivVeilederQuery,
   useVeiledereQuery,
@@ -21,7 +16,17 @@ const dropdownButtonTexts: DropdownButtonTexts = {
   reset: 'Avbryt',
 };
 
-const TildelVeileder = (props: ToolbarWrapperProps): ReactElement => {
+interface Props {
+  selectedPersoner: string[];
+  handleSelectAll: (checked: boolean) => void;
+  handleTildelVeileder: (veilederIdent: string) => void;
+}
+
+const TildelVeileder = ({
+  selectedPersoner,
+  handleTildelVeileder,
+  handleSelectAll,
+}: Props): ReactElement => {
   const veiledereQuery = useVeiledereQuery();
   const aktivVeilederQuery = useAktivVeilederQuery();
 
@@ -56,7 +61,7 @@ const TildelVeileder = (props: ToolbarWrapperProps): ReactElement => {
   };
 
   const assignToOtherVeilederButtonHandler = () => {
-    if (props.markertePersoner.length > 0) {
+    if (selectedPersoner.length > 0) {
       if (showList) {
         resetStateToDefault();
       } else {
@@ -66,9 +71,16 @@ const TildelVeileder = (props: ToolbarWrapperProps): ReactElement => {
     }
   };
 
+  const assignUsersToSelectedVeileder = (): void => {
+    if (chosenVeilederIdent && chosenVeilederIdent.length > 0) {
+      handleTildelVeileder(chosenVeilederIdent);
+    }
+    handleSelectAll(false);
+  };
+
   const chooseButtonHandler = (chosenVeilederIdent: string) => {
     if (chosenVeilederIdent && chosenVeilederIdent.length > 0) {
-      assignUsersToSelectedVeileder(props, chosenVeilederIdent);
+      assignUsersToSelectedVeileder();
       setShowList(false);
       setVeilederIsChosen(false);
       setShowError(false);
@@ -104,7 +116,7 @@ const TildelVeileder = (props: ToolbarWrapperProps): ReactElement => {
         text={'Tildel veileder'}
         onClick={assignToOtherVeilederButtonHandler}
         showList={showList}
-        userIsChecked={!hasNoCheckedPersoner(props.markertePersoner)}
+        active={selectedPersoner.length > 0}
         search={false}
       />
 

--- a/src/components/toolbar/OpenDropdownButton/OpenDropdownButton.tsx
+++ b/src/components/toolbar/OpenDropdownButton/OpenDropdownButton.tsx
@@ -58,7 +58,7 @@ const SearchIconWrapper = styled.span`
 
 interface AssignToVeilederButtonProps {
   text: string;
-  userIsChecked: boolean;
+  active: boolean;
   onClick: () => void;
   showList: boolean;
   search: boolean;
@@ -72,7 +72,7 @@ const OpenDropdownButton = (
   props: AssignToVeilederButtonProps
 ): ReactElement => {
   return (
-    <ButtonDiv className="openDropdownButton" active={props.userIsChecked}>
+    <ButtonDiv className="openDropdownButton" active={props.active}>
       <DropdownButtonButton
         className="openDropdownButton__button"
         onClick={props.onClick}

--- a/src/components/toolbar/SearchVeileder/SearchVeileder.tsx
+++ b/src/components/toolbar/SearchVeileder/SearchVeileder.tsx
@@ -140,7 +140,7 @@ const SearchVeileder = (): ReactElement => {
         <OpenDropdownButton
           text={`Søk veileder (${activeVeilederFilter.length})`}
           showList={showList}
-          userIsChecked={true}
+          active={true}
           onClick={toggleShowList}
           search={true}
         />

--- a/src/components/toolbar/Toolbar.tsx
+++ b/src/components/toolbar/Toolbar.tsx
@@ -73,7 +73,11 @@ const Toolbar = (props: ToolbarProps) => {
     <ToolbarStyled>
       <Innhold>
         <Element>
-          <TildelVeileder {...props} />
+          <TildelVeileder
+            selectedPersoner={props.markertePersoner}
+            handleTildelVeileder={props.buttonHandler}
+            handleSelectAll={props.checkAllHandler}
+          />
           {tabType === OverviewTabType.ENHET_OVERVIEW && <SearchVeileder />}
         </Element>
         <PaginationContainer

--- a/src/utils/assignVeilederUtils.tsx
+++ b/src/utils/assignVeilederUtils.tsx
@@ -1,16 +1,5 @@
 import { VeilederDTO } from '@/api/types/veiledereTypes';
 import { sortVeiledereAlphabetically } from './veiledereUtils';
-import { ToolbarWrapperProps } from '@/components/toolbar/ToolbarWrapper';
-
-export const assignUsersToSelectedVeileder = (
-  { buttonHandler, checkAllHandler }: ToolbarWrapperProps,
-  selectedVeilederIdent: string
-): void => {
-  if (selectedVeilederIdent && selectedVeilederIdent.length > 0) {
-    buttonHandler(selectedVeilederIdent);
-  }
-  checkAllHandler(false);
-};
 
 export const filterVeiledereOnInput = (
   veiledere: VeilederDTO[],
@@ -28,10 +17,6 @@ export const filterVeiledereOnInput = (
     return sortVeiledereAlphabetically(filteredVeiledere);
   }
   return filteredVeiledere;
-};
-
-export const hasNoCheckedPersoner = (personer: string[]): boolean => {
-  return personer.length === 0;
 };
 
 export const isInputGiven = (input: string): boolean => {


### PR DESCRIPTION
Først Refactor-commit ble uteglemt i forrige PR. Har i tillegg gjort `TildelVeileder` mindre avhengig av `ToolbarWrapperProps` ved å ikke importere props derfra. Gjør det enklere å ta i bruk `TildelVeileder` fra ny Aksel-tabell-komponent.
