### PR TITLE
IS-2457: Move warning-icon from own column to name or personident column

### DIFF
--- a/mock/data/personoversiktEnhetMock.ts
+++ b/mock/data/personoversiktEnhetMock.ts
@@ -129,7 +129,7 @@ export const personoversiktEnhetMock: PersonOversiktStatusDTO[] = [
   {
     ...behandletPerson,
     fnr: '59999933333',
-    navn: 'Korrupt Bolle',
+    navn: '',
     enhet: '0316',
     veilederIdent: 'Z101010',
     motebehovUbehandlet: true,

--- a/src/api/types/personregisterTypes.ts
+++ b/src/api/types/personregisterTypes.ts
@@ -6,14 +6,6 @@ import {
 } from './personoversiktTypes';
 
 export type Skjermingskode = 'INGEN' | 'DISKRESJONSMERKET' | 'EGEN_ANSATT';
-export type ReadableSkjermingskode =
-  | 'ingen'
-  | 'diskresjonsmerket'
-  | 'egen ansatt';
-export type ReadableSkjermingskodeMap = Record<
-  Skjermingskode,
-  ReadableSkjermingskode
->;
 
 export interface PersonData {
   navn: string;

--- a/src/components/Labels.tsx
+++ b/src/components/Labels.tsx
@@ -13,15 +13,13 @@ export const Labels = ({ personData }: LabelColumnProps) => {
   const showSkjermingskode = skjermingskode && skjermingskode !== 'INGEN';
 
   return (
-    <div className="flex">
-      {showSkjermingskode && (
-        <Tooltip content={getReadableSkjermingskode(skjermingskode)}>
-          <ExclamationmarkTriangleFillIcon
-            fontSize="1.5rem"
-            color="var(--a-orange-600)"
-          />
-        </Tooltip>
-      )}
-    </div>
+    showSkjermingskode && (
+      <Tooltip content={getReadableSkjermingskode(skjermingskode)}>
+        <ExclamationmarkTriangleFillIcon
+          fontSize="1.5rem"
+          color="var(--a-orange-600)"
+        />
+      </Tooltip>
+    )
   );
 };

--- a/src/components/LinkSyfomodiaperson.tsx
+++ b/src/components/LinkSyfomodiaperson.tsx
@@ -1,8 +1,9 @@
 import React, { ReactElement } from 'react';
 import Lenke from 'nav-frontend-lenker';
 import { PersonData } from '@/api/types/personregisterTypes';
-import { fullNaisUrlDefault } from './miljoUtil';
-import { capitalizeHyphenatedWords } from './stringUtil';
+import { fullNaisUrlDefault } from '@/utils/miljoUtil';
+import { Labels } from '@/components/Labels';
+import { useAktivBruker } from '@/data/modiacontext/useAktivBruker';
 
 export const lenkeTilModia = (personData: PersonData) => {
   let path = `/sykefravaer`;
@@ -36,53 +37,38 @@ export const lenkeTilModia = (personData: PersonData) => {
   return fullNaisUrlDefault('syfomodiaperson', path);
 };
 
-export const formatNameCorrectly = (navn?: string): string => {
-  if (!navn) return '';
-  const nameList = navn.split(' ');
+interface Props {
+  personData: PersonData;
+  personident: string;
+  linkText: string;
+}
 
-  if (nameList.length > 1) {
-    const lastName = nameList.pop() || '';
-    nameList.unshift(`${lastName},`);
-  }
+export function LinkSyfomodiaperson({
+  personData,
+  personident,
+  linkText,
+}: Props): ReactElement {
+  const aktivBruker = useAktivBruker();
+  const onPersonClick = () => {
+    aktivBruker.mutate(personident, {
+      onSuccess: () => {
+        window.location.href = lenkeTilModia(personData);
+      },
+    });
+  };
 
-  return nameList.map(capitalizeHyphenatedWords).join(' ');
-};
-
-export const lenkeTilModiaEnkeltperson = (
-  personData: PersonData,
-  onClick: () => void
-) => {
   return (
-    <Lenke
-      onClick={(event) => {
-        event.preventDefault();
-        onClick();
-      }}
-      href={lenkeTilModia(personData)}
-    >
-      {formatNameCorrectly(personData.navn)}
-    </Lenke>
+    <div className="flex items-center gap-2">
+      <Lenke
+        onClick={(event) => {
+          event.preventDefault();
+          onPersonClick();
+        }}
+        href={lenkeTilModia(personData)}
+      >
+        {linkText}
+      </Lenke>
+      <Labels personData={personData} />
+    </div>
   );
-};
-
-export const lenkeTilModiaEnkeltpersonFnr = (
-  personData: PersonData,
-  fnr: string,
-  onClick: () => void
-): ReactElement | string => {
-  const hasPersonName = personData.navn && personData.navn.length > 0;
-  if (hasPersonName) {
-    return fnr;
-  }
-  return (
-    <Lenke
-      onClick={(event) => {
-        event.preventDefault();
-        onClick();
-      }}
-      href={lenkeTilModia(personData)}
-    >
-      {fnr}
-    </Lenke>
-  );
-};
+}

--- a/src/components/NewOversiktTable.tsx
+++ b/src/components/NewOversiktTable.tsx
@@ -2,17 +2,12 @@ import React, { ReactElement } from 'react';
 import { Checkbox, Table } from '@navikt/ds-react';
 import { VeilederColumn } from '@/components/VeilederColumn';
 import { PersonData } from '@/api/types/personregisterTypes';
-import {
-  lenkeTilModia,
-  lenkeTilModiaEnkeltperson,
-  lenkeTilModiaEnkeltpersonFnr,
-} from '@/utils/lenkeUtil';
-import { useAktivBruker } from '@/data/modiacontext/useAktivBruker';
 import { PersonRadVirksomhetColumn } from '@/components/PersonRadVirksomhetColumn';
 import { OppfolgingstilfelleDTO } from '@/api/types/personoversiktTypes';
 import { FristColumn } from '@/components/FristColumn';
-import { Labels } from '@/components/Labels';
 import { Sorting, SortingKey, useSorting } from '@/hooks/useSorting';
+import { LinkSyfomodiaperson } from '@/components/LinkSyfomodiaperson';
+import { toLastnameFirstnameFormat } from '@/utils/stringUtil';
 
 const getVarighetOppfolgingstilfelle = (
   oppfolgingstilfelle: OppfolgingstilfelleDTO | undefined
@@ -37,7 +32,6 @@ export const NewOversiktTable = ({
   sorting,
   setSorting,
 }: Props): ReactElement => {
-  const aktivBruker = useAktivBruker();
   const { columns } = useSorting();
 
   const handleSort = (sortKey: string | undefined) => {
@@ -54,14 +48,6 @@ export const NewOversiktTable = ({
         direction: newDirection,
       });
     }
-  };
-
-  const onPersonClick = (fnr: string, personData: PersonData) => {
-    aktivBruker.mutate(fnr, {
-      onSuccess: () => {
-        window.location.href = lenkeTilModia(personData);
-      },
-    });
   };
 
   const allRowsSelected = personListe.length === selectedRows.length;
@@ -126,13 +112,23 @@ export const NewOversiktTable = ({
               </Checkbox>
             </Table.DataCell>
             <Table.HeaderCell scope="row" textSize="small">
-              {lenkeTilModiaEnkeltperson(persondata, () =>
-                onPersonClick(fnr, persondata)
+              {persondata.navn.length > 0 && (
+                <LinkSyfomodiaperson
+                  personData={persondata}
+                  personident={fnr}
+                  linkText={toLastnameFirstnameFormat(persondata.navn)}
+                />
               )}
             </Table.HeaderCell>
             <Table.DataCell textSize="small">
-              {lenkeTilModiaEnkeltpersonFnr(persondata, fnr, () =>
-                onPersonClick(fnr, persondata)
+              {persondata.navn.length > 0 ? (
+                fnr
+              ) : (
+                <LinkSyfomodiaperson
+                  personData={persondata}
+                  personident={fnr}
+                  linkText={fnr}
+                />
               )}
             </Table.DataCell>
             <Table.DataCell textSize="small">
@@ -148,9 +144,6 @@ export const NewOversiktTable = ({
             </Table.DataCell>
             <Table.DataCell textSize="small">
               <FristColumn personData={persondata} />
-            </Table.DataCell>
-            <Table.DataCell textSize="small">
-              <Labels personData={persondata} />
             </Table.DataCell>
           </Table.Row>
         ))}

--- a/src/utils/personDataUtil.ts
+++ b/src/utils/personDataUtil.ts
@@ -1,18 +1,19 @@
 import {
   PersonData,
   PersonregisterState,
-  ReadableSkjermingskodeMap,
   Skjermingskode,
 } from '@/api/types/personregisterTypes';
 import { earliestDate, latestDate } from '@/utils/dateUtils';
 
-const readableSkjermingskoder: ReadableSkjermingskodeMap = {
-  INGEN: 'ingen',
-  DISKRESJONSMERKET: 'diskresjonsmerket',
-  EGEN_ANSATT: 'egen ansatt',
-};
 export const getReadableSkjermingskode = (skjermingskode: Skjermingskode) => {
-  return readableSkjermingskoder[skjermingskode];
+  switch (skjermingskode) {
+    case 'INGEN':
+      return 'Ingen';
+    case 'DISKRESJONSMERKET':
+      return 'Diskresjonsmerket';
+    case 'EGEN_ANSATT':
+      return 'Egen ansatt';
+  }
 };
 
 export const mapPersonregisterToCompanyList = (

--- a/src/utils/stringUtil.ts
+++ b/src/utils/stringUtil.ts
@@ -5,3 +5,15 @@ export const uppercaseFirstLetter = (word: string): string => {
 export const capitalizeHyphenatedWords = (word: string): string => {
   return word.split('-').map(uppercaseFirstLetter).join('-');
 };
+
+export const toLastnameFirstnameFormat = (navn: string): string => {
+  if (!navn.length) return '';
+  const nameList = navn.split(' ');
+
+  if (nameList.length > 1) {
+    const lastName = nameList.pop() || '';
+    nameList.unshift(`${lastName},`);
+  }
+
+  return nameList.map(capitalizeHyphenatedWords).join(' ');
+};

--- a/test/components/NewOversiktTableTest.tsx
+++ b/test/components/NewOversiktTableTest.tsx
@@ -13,7 +13,7 @@ import {
   Skjermingskode,
 } from '@/api/types/personregisterTypes';
 import { AktivitetskravStatus } from '@/api/types/personoversiktTypes';
-import { formatNameCorrectly } from '@/utils/lenkeUtil';
+import { toLastnameFirstnameFormat } from '@/utils/stringUtil';
 
 const queryClient = testQueryClient();
 
@@ -94,7 +94,7 @@ describe('NewOversiktTable', () => {
 
     expect(
       screen.getByRole('link', {
-        name: formatNameCorrectly(defaultPersonData.navn),
+        name: toLastnameFirstnameFormat(defaultPersonData.navn),
       })
     ).to.exist;
     expect(screen.getByText(testdata.fnr1)).to.exist;

--- a/test/utils/lenkeUtil.test.ts
+++ b/test/utils/lenkeUtil.test.ts
@@ -1,12 +1,12 @@
 import { describe, expect, it } from 'vitest';
-import { formatNameCorrectly } from '@/utils/lenkeUtil';
+import { toLastnameFirstnameFormat } from '@/utils/stringUtil';
 
 describe('lenkeUtil', () => {
-  describe('formatNameCorrectly', () => {
+  describe('formatPersonnameCorrectly', () => {
     it('Should format name with first and last name, last name first', () => {
       const name = 'first last';
       const expected = 'Last, First';
-      const result = formatNameCorrectly(name);
+      const result = toLastnameFirstnameFormat(name);
 
       expect(result).to.deep.equal(expected);
     });
@@ -14,7 +14,7 @@ describe('lenkeUtil', () => {
     it('Should format name with first, middle and last name, last name first', () => {
       const name = 'first middle last';
       const expected = 'Last, First Middle';
-      const result = formatNameCorrectly(name);
+      const result = toLastnameFirstnameFormat(name);
 
       expect(result).to.deep.equal(expected);
     });
@@ -22,7 +22,7 @@ describe('lenkeUtil', () => {
     it('Should format name with only last name', () => {
       const name = 'last';
       const expected = 'Last';
-      const result = formatNameCorrectly(name);
+      const result = toLastnameFirstnameFormat(name);
 
       expect(result).to.deep.equal(expected);
     });
@@ -30,7 +30,7 @@ describe('lenkeUtil', () => {
     it('Should format name with no name', () => {
       const name = '';
       const expected = '';
-      const result = formatNameCorrectly(name);
+      const result = toLastnameFirstnameFormat(name);
 
       expect(result).to.deep.equal(expected);
     });
@@ -38,9 +38,16 @@ describe('lenkeUtil', () => {
     it('Format names with hyphen, last name first', () => {
       const name = 'namey dash-name nameson';
       const expected = 'Nameson, Namey Dash-Name';
-      const result = formatNameCorrectly(name);
+      const result = toLastnameFirstnameFormat(name);
 
       expect(result).to.deep.equal(expected);
+    });
+
+    it('Empty string when no name', () => {
+      const name = '';
+      const result = toLastnameFirstnameFormat(name);
+
+      expect(result).to.deep.equal('');
     });
   });
 });

--- a/test/utils/personDataUtil.test.ts
+++ b/test/utils/personDataUtil.test.ts
@@ -1,13 +1,10 @@
 import { describe, expect, it } from 'vitest';
-import {
-  PersonData,
-  ReadableSkjermingskode,
-} from '@/api/types/personregisterTypes';
+import { PersonData } from '@/api/types/personregisterTypes';
 import { getReadableSkjermingskode } from '@/utils/personDataUtil';
 import { testdata } from '../data/fellesTestdata';
 
-const INGEN: ReadableSkjermingskode = 'ingen';
-const EGEN_ANSATT: ReadableSkjermingskode = 'egen ansatt';
+const INGEN = 'Ingen';
+const EGEN_ANSATT = 'Egen ansatt';
 
 describe('personDataUtils', () => {
   describe('getReadableSkjermingskode', () => {


### PR DESCRIPTION
### Hva har blitt lagt til✨🌈

Det er jo en litt rar funksjonalitet det her med å defaulte til at fnr er link hvis man mangler navn. Tror egentlig det bare oppstår i dev at vi mangler navn 🤔

- Flytter varseltrekant fra egen kolonne til navnet (eller fnr)
- Lager egen komponent for lenka ut + varsel-labelen
- Ryddet litt i utils-kode

### Screenshots 📸✨

<img width="610" alt="image" src="https://github.com/navikt/syfooversikt/assets/37441744/d21d92ff-00a4-42e8-84aa-ae95adb99503">