### PR TITLE
IS-2492: Show sen oppfolging kandidat in oversikt

### DIFF
--- a/mock/data/personoversiktEnhetMock.ts
+++ b/mock/data/personoversiktEnhetMock.ts
@@ -20,6 +20,7 @@ const behandletPerson: PersonOversiktUbehandletStatusDTO = {
   aktivitetskravVurderStansUbehandlet: false,
   arbeidsuforhetvurdering: null,
   friskmeldingTilArbeidsformidlingFom: null,
+  snartSluttPaSykepengene: null,
 };
 
 export const personoversiktEnhetMock: PersonOversiktStatusDTO[] = [
@@ -590,26 +591,15 @@ export const personoversiktEnhetMock: PersonOversiktStatusDTO[] = [
   },
   {
     ...behandletPerson,
-    fnr: '99999966679',
-    navn: 'Ikke Viseland',
+    fnr: '99998966679',
+    navn: 'Frisk T. Arbeidsformidlesen',
     enhet: '0316',
     veilederIdent: 'Z101010',
     motestatus: undefined,
-    aktivitetskrav: AktivitetskravStatus.AVVENT,
-    aktivitetskravActive: false,
+    aktivitetskrav: null,
     aktivitetskravVurderingFrist: null,
-    oppfolgingsoppgave: null,
-    friskmeldingTilArbeidsformidlingFom: new Date('2099-01-01'),
-    latestOppfolgingstilfelle: {
-      oppfolgingstilfelleStart: new Date('2024-01-01'),
-      oppfolgingstilfelleEnd: new Date('2024-12-31'),
-      varighetUker: 2,
-      virksomhetList: [
-        {
-          virksomhetsnummer: '987654322',
-          virksomhetsnavn: 'NAV Investments',
-        },
-      ],
+    snartSluttPaSykepengene: {
+      uuid: 'uuid',
     },
   },
 ];

--- a/src/api/types/personoversiktTypes.ts
+++ b/src/api/types/personoversiktTypes.ts
@@ -30,6 +30,7 @@ export interface PersonOversiktUbehandletStatusDTO {
   behandlerBerOmBistandUbehandlet: boolean;
   arbeidsuforhetvurdering: ArbeidsuforhetvurderingDTO | null;
   friskmeldingTilArbeidsformidlingFom: Date | null;
+  snartSluttPaSykepengene: SnartSluttPaSykepengeneDTO | null;
   oppfolgingsoppgave: OppfolgingsoppgaveDTO | null;
 }
 
@@ -63,6 +64,11 @@ export interface ArbeidsuforhetvurderingDTO {
 
 export interface ArbeidsuforhetVarselDTO {
   svarfrist: Date;
+}
+
+// Hva trenger vi at denne inneholder?
+export interface SnartSluttPaSykepengeneDTO {
+  uuid: string;
 }
 
 export interface OppfolgingsoppgaveDTO {

--- a/src/api/types/personregisterTypes.ts
+++ b/src/api/types/personregisterTypes.ts
@@ -3,6 +3,7 @@ import {
   ArbeidsuforhetvurderingDTO,
   OppfolgingsoppgaveDTO,
   OppfolgingstilfelleDTO,
+  SnartSluttPaSykepengeneDTO,
 } from './personoversiktTypes';
 
 export type Skjermingskode = 'INGEN' | 'DISKRESJONSMERKET' | 'EGEN_ANSATT';
@@ -34,6 +35,7 @@ export interface PersonData {
   behandlerBerOmBistandUbehandlet: boolean;
   friskmeldingTilArbeidsformidlingFom: Date | null;
   arbeidsuforhetvurdering: ArbeidsuforhetvurderingDTO | null;
+  snartSluttPaSykepengene: SnartSluttPaSykepengeneDTO | null;
   oppfolgingsoppgave: OppfolgingsoppgaveDTO | null;
 }
 

--- a/src/components/HendelseTypeFilter.tsx
+++ b/src/components/HendelseTypeFilter.tsx
@@ -24,6 +24,7 @@ export const HendelseTekster = {
   BEHANDLER_BER_OM_BISTAND: 'Behandler ber om bistand',
   ARBEIDSUFORHET: '§8-4 Arbeidsuførhet',
   FRISKMELDING_TIL_ARBEIDSFORMIDLING: '§8-5 Friskmelding',
+  SNART_SLUTT_PA_SYKEPENGENE: 'Snart slutt på sykepengene',
 } as const;
 
 type HendelseTeksterKeys = keyof typeof HendelseTekster;
@@ -50,6 +51,7 @@ const enkeltFilterFraTekst = (
     behandlerBerOmBistand: false,
     isAktivArbeidsuforhetvurdering: false,
     harFriskmeldingTilArbeidsformidling: false,
+    isSnartSluttPaSykepengeneChecked: false,
   };
   return lagNyttFilter(filter, tekst, checked);
 };
@@ -110,6 +112,10 @@ const lagNyttFilter = (
       filter.harFriskmeldingTilArbeidsformidling = checked;
       return filter;
     }
+    case HendelseTekster.SNART_SLUTT_PA_SYKEPENGENE: {
+      filter.isSnartSluttPaSykepengeneChecked = checked;
+      return filter;
+    }
   }
 };
 
@@ -142,6 +148,8 @@ const isCheckedInState = (
       return state.isAktivArbeidsuforhetvurdering;
     case HendelseTekster.FRISKMELDING_TIL_ARBEIDSFORMIDLING:
       return state.harFriskmeldingTilArbeidsformidling;
+    case HendelseTekster.SNART_SLUTT_PA_SYKEPENGENE:
+      return state.isSnartSluttPaSykepengeneChecked;
   }
 };
 
@@ -164,6 +172,8 @@ const showCheckbox = (
       return true;
     case 'FRISKMELDING_TIL_ARBEIDSFORMIDLING':
       return toggles.isFrisktilarbeidEnabled;
+    case 'SNART_SLUTT_PA_SYKEPENGENE':
+      return toggles.isOppfolgingISenFaseEnabled;
     case 'UFORDELTE_BRUKERE':
       return tabType === OverviewTabType.ENHET_OVERVIEW;
   }

--- a/src/context/filters/filterContextState.ts
+++ b/src/context/filters/filterContextState.ts
@@ -16,6 +16,7 @@ export interface HendelseTypeFilters {
   behandlerBerOmBistand: boolean;
   isAktivArbeidsuforhetvurdering: boolean;
   harFriskmeldingTilArbeidsformidling: boolean;
+  isSnartSluttPaSykepengeneChecked: boolean;
 }
 
 export interface FilterState {
@@ -50,5 +51,6 @@ export const filterInitialState: FilterState = {
     behandlerBerOmBistand: false,
     isAktivArbeidsuforhetvurdering: false,
     harFriskmeldingTilArbeidsformidling: false,
+    isSnartSluttPaSykepengeneChecked: false,
   },
 };

--- a/src/data/personoversiktHooks.ts
+++ b/src/data/personoversiktHooks.ts
@@ -36,6 +36,7 @@ const filteredPersonOversiktStatusList = (
       arbeidsuforhetvurdering: personOversiktStatus.arbeidsuforhetvurdering,
       friskmeldingTilArbeidsformidlingFom:
         personOversiktStatus.friskmeldingTilArbeidsformidlingFom,
+      snartSluttPaSykepengene: personOversiktStatus.snartSluttPaSykepengene,
       oppfolgingsoppgave: personOversiktStatus.oppfolgingsoppgave,
     };
 

--- a/src/data/unleash/types/unleash_types.ts
+++ b/src/data/unleash/types/unleash_types.ts
@@ -6,9 +6,11 @@ export type Toggles = {
 export enum ToggleNames {
   isFlexjarArenaEnabled = 'isFlexjarArenaEnabled',
   isFrisktilarbeidEnabled = 'isFrisktilarbeidEnabled',
+  isOppfolgingISenFaseEnabled = 'isOppfolgingISenFaseEnabled',
 }
 
 export const defaultToggles: Toggles = {
   isFlexjarArenaEnabled: false,
   isFrisktilarbeidEnabled: false,
+  isOppfolgingISenFaseEnabled: true,
 };

--- a/src/utils/hendelseFilteringUtils.tsx
+++ b/src/utils/hendelseFilteringUtils.tsx
@@ -10,7 +10,7 @@ import {
 import { VeilederDTO } from '@/api/types/veiledereTypes';
 import { HendelseTypeFilters } from '@/context/filters/filterContextState';
 import { isFuture, isPast, isToday } from '@/utils/dateUtils';
-import { Sorting, SortDirection } from '@/hooks/useSorting';
+import { SortDirection, Sorting } from '@/hooks/useSorting';
 
 export class Filterable<T> {
   value: T;
@@ -211,6 +211,8 @@ const matchesFilter = (
       return !filters[key] || !!personData.arbeidsuforhetvurdering;
     case 'harFriskmeldingTilArbeidsformidling':
       return !filters[key] || !!personData.friskmeldingTilArbeidsformidlingFom;
+    case 'isSnartSluttPaSykepengeneChecked':
+      return !filters[key] || !!personData.snartSluttPaSykepengene;
   }
 };
 

--- a/src/utils/toPersondata.ts
+++ b/src/utils/toPersondata.ts
@@ -37,6 +37,7 @@ export const toPersonData = (
       arbeidsuforhetvurdering: person.arbeidsuforhetvurdering,
       friskmeldingTilArbeidsformidlingFom:
         person.friskmeldingTilArbeidsformidlingFom,
+      snartSluttPaSykepengene: person.snartSluttPaSykepengene,
       oppfolgingsoppgave: person.oppfolgingsoppgave,
     };
   });

--- a/test/components/FristColumnTest.tsx
+++ b/test/components/FristColumnTest.tsx
@@ -26,6 +26,7 @@ const defaultPersonData: PersonData = {
   behandlerBerOmBistandUbehandlet: false,
   arbeidsuforhetvurdering: null,
   friskmeldingTilArbeidsformidlingFom: null,
+  snartSluttPaSykepengene: null,
   oppfolgingsoppgave: null,
 };
 

--- a/test/components/NewOversiktTableTest.tsx
+++ b/test/components/NewOversiktTableTest.tsx
@@ -34,6 +34,7 @@ const defaultPersonData: PersonData = {
   behandlerBerOmBistandUbehandlet: false,
   arbeidsuforhetvurdering: null,
   friskmeldingTilArbeidsformidlingFom: null,
+  snartSluttPaSykepengene: null,
   oppfolgingsoppgave: null,
 };
 const personDataAktivitetskravAvventUtenFrist: PersonData = {

--- a/test/components/Sokeresultat.test.tsx
+++ b/test/components/Sokeresultat.test.tsx
@@ -70,6 +70,7 @@ describe('Sokeresultat', () => {
         behandlerBerOmBistand: false,
         isAktivArbeidsuforhetvurdering: false,
         harFriskmeldingTilArbeidsformidling: false,
+        isSnartSluttPaSykepengeneChecked: false,
       },
     };
 

--- a/test/query/personoversiktHooks.test.tsx
+++ b/test/query/personoversiktHooks.test.tsx
@@ -72,7 +72,8 @@ describe('personoversiktHooks tests', () => {
         person.dialogmotesvarUbehandlet ||
         person.behandlerBerOmBistandUbehandlet ||
         person.arbeidsuforhetvurdering !== null ||
-        person.friskmeldingTilArbeidsformidlingFom
+        person.friskmeldingTilArbeidsformidlingFom ||
+        person.snartSluttPaSykepengene
       );
     });
     expect(allPersonsUbehandlet).to.be.true;

--- a/test/utils/hendelseFilteringUtilsTest.ts
+++ b/test/utils/hendelseFilteringUtilsTest.ts
@@ -35,6 +35,7 @@ export const createPersonDataWithName = (name: string): PersonData => {
     behandlerBerOmBistandUbehandlet: false,
     arbeidsuforhetvurdering: null,
     friskmeldingTilArbeidsformidlingFom: null,
+    snartSluttPaSykepengene: null,
     oppfolgingsoppgave: null,
   };
 };
@@ -52,6 +53,7 @@ const defaulthendelseFilter: HendelseTypeFilters = {
   behandlerBerOmBistand: false,
   isAktivArbeidsuforhetvurdering: false,
   harFriskmeldingTilArbeidsformidling: false,
+  isSnartSluttPaSykepengeneChecked: false,
 };
 
 describe('hendelseFilteringUtils', () => {


### PR DESCRIPTION
### Hva har blitt lagt til✨🌈
- Legger til at vi viser oppfolging i sen fase kandidater i oversikten.
- Se [tilhørende PR](https://github.com/navikt/syfooversiktsrv/pull/389) i `syfooversiktsrv`

### Screenshots 📸✨
![Screenshot 2024-07-02 at 10 16 00](https://github.com/navikt/syfooversikt/assets/11747383/ffbc85e6-ed51-4a26-8416-b9b8eedbdc3c)


