### PR TITLE
IS-2475: Fix hendelse column

### DIFF
--- a/mock/data/personoversiktEnhetMock.ts
+++ b/mock/data/personoversiktEnhetMock.ts
@@ -7,6 +7,7 @@ import {
   PersonOversiktUbehandletStatusDTO,
 } from '../../src/api/types/personoversiktTypes';
 import { veilederMock } from './veilederMock';
+import dayjs from 'dayjs';
 
 const behandletPerson: PersonOversiktUbehandletStatusDTO = {
   oppfolgingsplanLPSBistandUbehandlet: null,
@@ -40,7 +41,7 @@ export const personoversiktEnhetMock: PersonOversiktStatusDTO[] = [
     behandlerBerOmBistandUbehandlet: false,
     arbeidsuforhetvurdering: {
       varsel: {
-        svarfrist: new Date('2022-12-01T10:12:05.913826'),
+        svarfrist: new Date('2026-12-01T10:12:05.913826'),
       },
     },
   },
@@ -51,9 +52,18 @@ export const personoversiktEnhetMock: PersonOversiktStatusDTO[] = [
     enhet: '0316',
     veilederIdent: null,
     motebehovUbehandlet: true,
-    aktivitetskrav: AktivitetskravStatus.UNNTAK,
+    aktivitetskrav: AktivitetskravStatus.AVVENT,
     aktivitetskravActive: false,
     aktivitetskravVurderingFrist: null,
+    aktivitetskravvurdering: {
+      status: AktivitetskravStatus.AVVENT,
+      vurderinger: [
+        {
+          status: AktivitetskravStatus.AVVENT,
+          frist: dayjs(new Date()).add(-2, 'day').toDate(),
+        },
+      ],
+    },
     motestatus: undefined,
     behandlerdialogUbehandlet: true,
     oppfolgingsoppgave: null,
@@ -77,7 +87,7 @@ export const personoversiktEnhetMock: PersonOversiktStatusDTO[] = [
         {
           status: AktivitetskravStatus.FORHANDSVARSEL,
           varsel: {
-            svarfrist: new Date('2022-12-01T10:12:05.913826'),
+            svarfrist: new Date('2024-12-01'),
           },
         },
       ],
@@ -212,7 +222,7 @@ export const personoversiktEnhetMock: PersonOversiktStatusDTO[] = [
     fnr: '18999955555',
     navn: 'Bord Stolesen',
     enhet: '0316',
-    veilederIdent: null,
+    veilederIdent: 'Z999999',
     motebehovUbehandlet: true,
     oppfolgingsplanLPSBistandUbehandlet: true,
     motestatus: undefined,

--- a/src/api/types/personoversiktTypes.ts
+++ b/src/api/types/personoversiktTypes.ts
@@ -19,6 +19,7 @@ export enum AktivitetskravStatus {
   FORHANDSVARSEL = 'FORHANDSVARSEL',
   IKKE_AKTUELL = 'IKKE_AKTUELL',
   LUKKET = 'LUKKET',
+  NY_VURDERING = 'NY_VURDERING',
 }
 
 export interface PersonOversiktUbehandletStatusDTO {

--- a/src/components/NewOversiktTable.tsx
+++ b/src/components/NewOversiktTable.tsx
@@ -10,6 +10,8 @@ import { LinkSyfomodiaperson } from '@/components/LinkSyfomodiaperson';
 import { toLastnameFirstnameFormat } from '@/utils/stringUtil';
 import { getHendelser } from '@/utils/statusColumnUtils';
 import { useFeatureToggles } from '@/data/unleash/unleashQueryHooks';
+import { useTabType } from '@/context/tab/TabTypeContext';
+import { OverviewTabType } from '@/konstanter';
 
 const getVarighetOppfolgingstilfelle = (
   oppfolgingstilfelle: OppfolgingstilfelleDTO | undefined
@@ -36,6 +38,7 @@ export const NewOversiktTable = ({
 }: Props): ReactElement => {
   const { columns } = useSorting();
   const { toggles } = useFeatureToggles();
+  const { tabType } = useTabType();
 
   const handleSort = (sortKey: string | undefined) => {
     if (sortKey === sorting.orderBy && sorting.direction === 'descending') {
@@ -96,7 +99,10 @@ export const NewOversiktTable = ({
           {columns
             .filter(
               (column) =>
-                toggles.isHendelseColumnEnabled || column.sortKey !== 'HENDELSE'
+                (toggles.isHendelseColumnEnabled ||
+                  column.sortKey !== 'HENDELSE') &&
+                (tabType === OverviewTabType.ENHET_OVERVIEW ||
+                  column.sortKey !== 'VEILEDER')
             )
             .map((col, index) => (
               <Table.ColumnHeader key={index} sortKey={col.sortKey} sortable>
@@ -142,9 +148,11 @@ export const NewOversiktTable = ({
             <Table.DataCell textSize="small">
               <PersonRadVirksomhetColumn personData={persondata} />
             </Table.DataCell>
-            <Table.DataCell textSize="small">
-              <VeilederColumn personData={persondata} />
-            </Table.DataCell>
+            {tabType === OverviewTabType.ENHET_OVERVIEW && (
+              <Table.DataCell textSize="small">
+                <VeilederColumn personData={persondata} />
+              </Table.DataCell>
+            )}
             <Table.DataCell textSize="small">
               {getVarighetOppfolgingstilfelle(
                 persondata.latestOppfolgingstilfelle
@@ -154,7 +162,10 @@ export const NewOversiktTable = ({
               <FristColumn personData={persondata} />
             </Table.DataCell>
             {toggles.isHendelseColumnEnabled && (
-              <Table.DataCell textSize="small">
+              <Table.DataCell
+                textSize="small"
+                className="[&>*:not(:last-child)]:mb-1.5"
+              >
                 {getHendelser(persondata).map((status, index) => (
                   <p key={index} className="m-0">
                     {status}


### PR DESCRIPTION
### Hva har blitt lagt til✨🌈

Flere ting som ikke var helt gjennomtestet her, så prøver å fikse opp litt:
- Manglet `NY_VURDERING` på aktivitetskrav, den må vi også vise i tabellen
- Litt marginer mellom hver hendelse slik at man kan skille de fra hverandre når det er flere
- Aktivitetskrav ligger både under `aktivitetskrav` og `aktivitetskravvurdering` i DTOen, så må ta høyde for begge
- Litt trøbbel med datoer på frister: Må wrappe i `new Date()` for å være sikker på at datoene kan brukes med `<` etc.
- Fikset testene vi kommenterte ut
- Fjerner Veileder-kolonnen når man står på "Min oversikt" for å gi mer plass

### Screenshots 📸✨
<img width="1431" alt="image" src="https://github.com/user-attachments/assets/07781cb5-0a2d-490b-81cd-acdff24d2179">

