### PR TITLE
IS-2596: Cleanup aktivitetskrav fields

### DIFF
--- a/mock/data/personoversiktEnhetMock.ts
+++ b/mock/data/personoversiktEnhetMock.ts
@@ -14,11 +14,9 @@ const behandletPerson: PersonOversiktUbehandletStatusDTO = {
   motebehovUbehandlet: null,
   dialogmotekandidat: undefined,
   dialogmotesvarUbehandlet: false,
-  aktivitetskravActive: false,
   behandlerdialogUbehandlet: false,
   oppfolgingsoppgave: null,
   behandlerBerOmBistandUbehandlet: false,
-  aktivitetskravVurderStansUbehandlet: false,
   arbeidsuforhetvurdering: null,
   friskmeldingTilArbeidsformidlingFom: null,
   isAktivSenOppfolgingKandidat: false,
@@ -32,9 +30,6 @@ export const personoversiktEnhetMock: PersonOversiktStatusDTO[] = [
     navn: 'Korrupt Heis',
     enhet: '0316',
     veilederIdent: null,
-    aktivitetskrav: AktivitetskravStatus.OPPFYLT,
-    aktivitetskravActive: false,
-    aktivitetskravVurderingFrist: null,
     oppfolgingsplanLPSBistandUbehandlet: true,
     motestatus: undefined,
     oppfolgingsoppgave: null,
@@ -52,9 +47,6 @@ export const personoversiktEnhetMock: PersonOversiktStatusDTO[] = [
     enhet: '0316',
     veilederIdent: null,
     motebehovUbehandlet: true,
-    aktivitetskrav: AktivitetskravStatus.AVVENT,
-    aktivitetskravActive: false,
-    aktivitetskravVurderingFrist: null,
     aktivitetskravvurdering: {
       status: AktivitetskravStatus.AVVENT,
       vurderinger: [
@@ -75,11 +67,7 @@ export const personoversiktEnhetMock: PersonOversiktStatusDTO[] = [
     enhet: '0316',
     veilederIdent: null,
     motebehovUbehandlet: true,
-    aktivitetskrav: AktivitetskravStatus.FORHANDSVARSEL,
-    aktivitetskravActive: false,
-    aktivitetskravVurderingFrist: null,
     motestatus: undefined,
-    aktivitetskravVurderStansUbehandlet: true,
     oppfolgingsoppgave: null,
     aktivitetskravvurdering: {
       status: AktivitetskravStatus.FORHANDSVARSEL,
@@ -99,8 +87,6 @@ export const personoversiktEnhetMock: PersonOversiktStatusDTO[] = [
     navn: 'Per Arbeidsuforvarselsen',
     enhet: '0316',
     veilederIdent: null,
-    aktivitetskrav: null,
-    aktivitetskravVurderingFrist: null,
     oppfolgingsplanLPSBistandUbehandlet: null,
     motestatus: undefined,
     oppfolgingsoppgave: null,
@@ -117,8 +103,6 @@ export const personoversiktEnhetMock: PersonOversiktStatusDTO[] = [
     enhet: '0316',
     veilederIdent: null,
     motebehovUbehandlet: true,
-    aktivitetskrav: null,
-    aktivitetskravVurderingFrist: null,
     motestatus: undefined,
     oppfolgingsoppgave: getOppfolgingsoppgave(new Date('2024-01-01')),
   },
@@ -129,12 +113,18 @@ export const personoversiktEnhetMock: PersonOversiktStatusDTO[] = [
     enhet: '0316',
     veilederIdent: null,
     motebehovUbehandlet: true,
-    aktivitetskrav: AktivitetskravStatus.AVVENT,
-    aktivitetskravActive: true,
-    aktivitetskravVurderingFrist: new Date('2022-12-08'),
     oppfolgingsplanLPSBistandUbehandlet: null,
     motestatus: undefined,
     oppfolgingsoppgave: getOppfolgingsoppgave(new Date('2024-01-01')),
+    aktivitetskravvurdering: {
+      status: AktivitetskravStatus.AVVENT,
+      vurderinger: [
+        {
+          status: AktivitetskravStatus.AVVENT,
+          frist: new Date('2022-12-08'),
+        },
+      ],
+    },
   },
   {
     ...behandletPerson,
@@ -143,8 +133,6 @@ export const personoversiktEnhetMock: PersonOversiktStatusDTO[] = [
     enhet: '0316',
     veilederIdent: null,
     motebehovUbehandlet: true,
-    aktivitetskrav: null,
-    aktivitetskravVurderingFrist: null,
     motestatus: undefined,
     oppfolgingsoppgave: getOppfolgingsoppgave(new Date('2024-04-01')),
     behandlerBerOmBistandUbehandlet: true,
@@ -156,11 +144,17 @@ export const personoversiktEnhetMock: PersonOversiktStatusDTO[] = [
     enhet: '0316',
     veilederIdent: 'Z101010',
     motebehovUbehandlet: true,
-    aktivitetskrav: AktivitetskravStatus.AVVENT,
-    aktivitetskravActive: false,
-    aktivitetskravVurderingFrist: new Date('2022-12-10'),
     motestatus: undefined,
     oppfolgingsoppgave: null,
+    aktivitetskravvurdering: {
+      status: AktivitetskravStatus.AVVENT,
+      vurderinger: [
+        {
+          status: AktivitetskravStatus.AVVENT,
+          frist: new Date('2022-12-10'),
+        },
+      ],
+    },
     latestOppfolgingstilfelle: {
       oppfolgingstilfelleStart: new Date('2022-10-25'),
       oppfolgingstilfelleEnd: new Date('2022-12-31'),
@@ -193,10 +187,16 @@ export const personoversiktEnhetMock: PersonOversiktStatusDTO[] = [
     veilederIdent: 'Z101010',
     motebehovUbehandlet: true,
     motestatus: undefined,
-    aktivitetskrav: AktivitetskravStatus.AVVENT,
-    aktivitetskravActive: false,
-    aktivitetskravVurderingFrist: new Date('2022-12-10'),
     oppfolgingsoppgave: null,
+    aktivitetskravvurdering: {
+      status: AktivitetskravStatus.AVVENT,
+      vurderinger: [
+        {
+          status: AktivitetskravStatus.AVVENT,
+          frist: new Date('2022-12-10'),
+        },
+      ],
+    },
     latestOppfolgingstilfelle: {
       oppfolgingstilfelleStart: new Date('2022-08-03'),
       oppfolgingstilfelleEnd: new Date('2022-12-31'),
@@ -226,10 +226,16 @@ export const personoversiktEnhetMock: PersonOversiktStatusDTO[] = [
     motebehovUbehandlet: true,
     oppfolgingsplanLPSBistandUbehandlet: true,
     motestatus: undefined,
-    aktivitetskrav: AktivitetskravStatus.AVVENT,
-    aktivitetskravActive: true,
-    aktivitetskravVurderingFrist: new Date('2023-04-01'),
     oppfolgingsoppgave: getOppfolgingsoppgave(new Date('2024-05-01')),
+    aktivitetskravvurdering: {
+      status: AktivitetskravStatus.AVVENT,
+      vurderinger: [
+        {
+          status: AktivitetskravStatus.AVVENT,
+          frist: new Date('2023-04-01'),
+        },
+      ],
+    },
     latestOppfolgingstilfelle: {
       oppfolgingstilfelleStart: new Date('2022-08-01'),
       oppfolgingstilfelleEnd: new Date('2022-12-31'),
@@ -253,10 +259,16 @@ export const personoversiktEnhetMock: PersonOversiktStatusDTO[] = [
     enhet: '0316',
     veilederIdent: 'M987654',
     motestatus: MoteStatusType.NYTT_TID_STED,
-    aktivitetskrav: AktivitetskravStatus.AVVENT,
-    aktivitetskravActive: false,
-    aktivitetskravVurderingFrist: new Date('2023-12-10'),
     oppfolgingsoppgave: null,
+    aktivitetskravvurdering: {
+      status: AktivitetskravStatus.AVVENT,
+      vurderinger: [
+        {
+          status: AktivitetskravStatus.AVVENT,
+          frist: new Date('2023-12-10'),
+        },
+      ],
+    },
     latestOppfolgingstilfelle: {
       oppfolgingstilfelleStart: new Date('2022-01-01'),
       oppfolgingstilfelleEnd: new Date('2022-12-31'),
@@ -278,10 +290,11 @@ export const personoversiktEnhetMock: PersonOversiktStatusDTO[] = [
     motebehovUbehandlet: true,
     motestatus: MoteStatusType.INNKALT,
     dialogmotesvarUbehandlet: true,
-    aktivitetskrav: AktivitetskravStatus.NY,
-    aktivitetskravActive: true,
-    aktivitetskravVurderingFrist: null,
     oppfolgingsoppgave: null,
+    aktivitetskravvurdering: {
+      status: AktivitetskravStatus.NY,
+      vurderinger: [],
+    },
     latestOppfolgingstilfelle: {
       oppfolgingstilfelleStart: new Date('2022-01-01'),
       oppfolgingstilfelleEnd: new Date('2022-12-31'),
@@ -302,9 +315,6 @@ export const personoversiktEnhetMock: PersonOversiktStatusDTO[] = [
     veilederIdent: 'M987654',
     dialogmotekandidat: true,
     motestatus: MoteStatusType.AVLYST,
-    aktivitetskrav: AktivitetskravStatus.STANS,
-    aktivitetskravActive: false,
-    aktivitetskravVurderingFrist: null,
     oppfolgingsoppgave: null,
     latestOppfolgingstilfelle: {
       oppfolgingstilfelleStart: new Date('2022-01-01'),
@@ -326,10 +336,16 @@ export const personoversiktEnhetMock: PersonOversiktStatusDTO[] = [
     veilederIdent: 'M987654',
     dialogmotekandidat: true,
     motestatus: undefined,
-    aktivitetskrav: AktivitetskravStatus.AVVENT,
-    aktivitetskravActive: false,
-    aktivitetskravVurderingFrist: new Date('2022-12-10'),
     oppfolgingsoppgave: null,
+    aktivitetskravvurdering: {
+      status: AktivitetskravStatus.AVVENT,
+      vurderinger: [
+        {
+          status: AktivitetskravStatus.AVVENT,
+          frist: new Date('2022-12-10'),
+        },
+      ],
+    },
     latestOppfolgingstilfelle: {
       oppfolgingstilfelleStart: new Date('2022-05-01'),
       oppfolgingstilfelleEnd: new Date('2022-12-31'),
@@ -350,9 +366,6 @@ export const personoversiktEnhetMock: PersonOversiktStatusDTO[] = [
     veilederIdent: 'Wienerbrød',
     oppfolgingsplanLPSBistandUbehandlet: true,
     motestatus: MoteStatusType.FERDIGSTILT,
-    aktivitetskrav: AktivitetskravStatus.UNNTAK,
-    aktivitetskravActive: false,
-    aktivitetskravVurderingFrist: null,
     oppfolgingsoppgave: getOppfolgingsoppgave(new Date('2024-01-01')),
     latestOppfolgingstilfelle: {
       oppfolgingstilfelleStart: new Date('2022-10-01'),
@@ -377,9 +390,6 @@ export const personoversiktEnhetMock: PersonOversiktStatusDTO[] = [
     enhet: '0316',
     veilederIdent: 'Wienerbrød',
     motestatus: undefined,
-    aktivitetskrav: AktivitetskravStatus.AUTOMATISK_OPPFYLT,
-    aktivitetskravActive: false,
-    aktivitetskravVurderingFrist: null,
     oppfolgingsoppgave: getOppfolgingsoppgave(new Date('2024-01-01')),
     latestOppfolgingstilfelle: {
       oppfolgingstilfelleStart: new Date('2022-01-01'),
@@ -401,10 +411,11 @@ export const personoversiktEnhetMock: PersonOversiktStatusDTO[] = [
     veilederIdent: 'Z999991',
     oppfolgingsplanLPSBistandUbehandlet: true,
     motestatus: undefined,
-    aktivitetskrav: AktivitetskravStatus.NY,
-    aktivitetskravActive: false,
-    aktivitetskravVurderingFrist: null,
     oppfolgingsoppgave: getOppfolgingsoppgave(new Date('2024-01-01')),
+    aktivitetskravvurdering: {
+      status: AktivitetskravStatus.NY,
+      vurderinger: [],
+    },
     latestOppfolgingstilfelle: {
       oppfolgingstilfelleStart: new Date('2022-01-01'),
       oppfolgingstilfelleEnd: new Date('2022-12-31'),
@@ -426,9 +437,6 @@ export const personoversiktEnhetMock: PersonOversiktStatusDTO[] = [
     oppfolgingsplanLPSBistandUbehandlet: true,
     motestatus: undefined,
     latestOppfolgingstilfelle: undefined,
-    aktivitetskrav: AktivitetskravStatus.OPPFYLT,
-    aktivitetskravActive: false,
-    aktivitetskravVurderingFrist: null,
     oppfolgingsoppgave: getOppfolgingsoppgave(new Date('2024-01-01')),
   },
   {
@@ -440,9 +448,6 @@ export const personoversiktEnhetMock: PersonOversiktStatusDTO[] = [
     oppfolgingsplanLPSBistandUbehandlet: null,
     motestatus: undefined,
     latestOppfolgingstilfelle: undefined,
-    aktivitetskrav: null,
-    aktivitetskravActive: false,
-    aktivitetskravVurderingFrist: null,
     oppfolgingsoppgave: null,
     arbeidsuforhetvurdering: {
       varsel: null,
@@ -455,9 +460,6 @@ export const personoversiktEnhetMock: PersonOversiktStatusDTO[] = [
     enhet: '0316',
     veilederIdent: 'Z101010',
     motestatus: MoteStatusType.NYTT_TID_STED,
-    aktivitetskrav: AktivitetskravStatus.IKKE_OPPFYLT,
-    aktivitetskravActive: false,
-    aktivitetskravVurderingFrist: null,
     oppfolgingsoppgave: null,
     latestOppfolgingstilfelle: {
       oppfolgingstilfelleStart: new Date('2022-01-01'),
@@ -478,10 +480,11 @@ export const personoversiktEnhetMock: PersonOversiktStatusDTO[] = [
     enhet: '0316',
     veilederIdent: 'Z101010',
     motestatus: MoteStatusType.INNKALT,
-    aktivitetskrav: AktivitetskravStatus.NY,
-    aktivitetskravActive: false,
-    aktivitetskravVurderingFrist: null,
     oppfolgingsoppgave: null,
+    aktivitetskravvurdering: {
+      status: AktivitetskravStatus.NY,
+      vurderinger: [],
+    },
     latestOppfolgingstilfelle: {
       oppfolgingstilfelleStart: new Date('2022-01-01'),
       oppfolgingstilfelleEnd: new Date('2022-12-31'),
@@ -502,9 +505,15 @@ export const personoversiktEnhetMock: PersonOversiktStatusDTO[] = [
     veilederIdent: 'Z101010',
     dialogmotekandidat: true,
     motestatus: MoteStatusType.AVLYST,
-    aktivitetskrav: AktivitetskravStatus.AVVENT,
-    aktivitetskravActive: false,
-    aktivitetskravVurderingFrist: new Date('2022-12-10'),
+    aktivitetskravvurdering: {
+      status: AktivitetskravStatus.AVVENT,
+      vurderinger: [
+        {
+          status: AktivitetskravStatus.AVVENT,
+          frist: new Date('2022-12-10'),
+        },
+      ],
+    },
     oppfolgingsoppgave: null,
     latestOppfolgingstilfelle: {
       oppfolgingstilfelleStart: new Date('2022-01-01'),
@@ -526,9 +535,15 @@ export const personoversiktEnhetMock: PersonOversiktStatusDTO[] = [
     veilederIdent: 'Z101010',
     dialogmotekandidat: true,
     motestatus: undefined,
-    aktivitetskrav: AktivitetskravStatus.AVVENT,
-    aktivitetskravActive: false,
-    aktivitetskravVurderingFrist: new Date('2022-12-20'),
+    aktivitetskravvurdering: {
+      status: AktivitetskravStatus.AVVENT,
+      vurderinger: [
+        {
+          status: AktivitetskravStatus.AVVENT,
+          frist: new Date('2022-12-20'),
+        },
+      ],
+    },
     oppfolgingsoppgave: null,
     latestOppfolgingstilfelle: {
       oppfolgingstilfelleStart: new Date('2022-01-01'),
@@ -549,9 +564,6 @@ export const personoversiktEnhetMock: PersonOversiktStatusDTO[] = [
     enhet: '0316',
     veilederIdent: 'Z101010',
     motestatus: MoteStatusType.FERDIGSTILT,
-    aktivitetskrav: AktivitetskravStatus.UNNTAK,
-    aktivitetskravActive: false,
-    aktivitetskravVurderingFrist: null,
     oppfolgingsoppgave: null,
     latestOppfolgingstilfelle: {
       oppfolgingstilfelleStart: new Date('2022-01-01'),
@@ -572,9 +584,6 @@ export const personoversiktEnhetMock: PersonOversiktStatusDTO[] = [
     enhet: '0316',
     veilederIdent: 'Z101010',
     motestatus: undefined,
-    aktivitetskrav: AktivitetskravStatus.UNNTAK,
-    aktivitetskravActive: false,
-    aktivitetskravVurderingFrist: null,
     oppfolgingsoppgave: null,
     latestOppfolgingstilfelle: {
       oppfolgingstilfelleStart: new Date('2022-01-01'),
@@ -595,9 +604,6 @@ export const personoversiktEnhetMock: PersonOversiktStatusDTO[] = [
     enhet: '0316',
     veilederIdent: 'Z101010',
     motestatus: undefined,
-    aktivitetskrav: AktivitetskravStatus.UNNTAK,
-    aktivitetskravActive: false,
-    aktivitetskravVurderingFrist: null,
     oppfolgingsoppgave: null,
     latestOppfolgingstilfelle: {
       oppfolgingstilfelleStart: new Date('2022-01-01'),
@@ -618,8 +624,6 @@ export const personoversiktEnhetMock: PersonOversiktStatusDTO[] = [
     enhet: '0316',
     veilederIdent: 'Z101010',
     motestatus: undefined,
-    aktivitetskrav: null,
-    aktivitetskravVurderingFrist: null,
     isAktivSenOppfolgingKandidat: true,
   },
 ];

--- a/src/api/types/personoversiktTypes.ts
+++ b/src/api/types/personoversiktTypes.ts
@@ -28,8 +28,6 @@ export interface PersonOversiktUbehandletStatusDTO {
   oppfolgingsplanLPSBistandUbehandlet: boolean | null;
   dialogmotekandidat: boolean | undefined;
   behandlerdialogUbehandlet: boolean;
-  aktivitetskravActive: boolean;
-  aktivitetskravVurderStansUbehandlet: boolean;
   behandlerBerOmBistandUbehandlet: boolean;
   arbeidsuforhetvurdering: ArbeidsuforhetvurderingDTO | null;
   friskmeldingTilArbeidsformidlingFom: Date | null;
@@ -46,8 +44,6 @@ export interface PersonOversiktStatusDTO
   veilederIdent: string | null;
   motestatus: MoteStatusType | undefined;
   latestOppfolgingstilfelle?: OppfolgingstilfelleDTO;
-  aktivitetskrav: AktivitetskravStatus | null;
-  aktivitetskravVurderingFrist: Date | null;
 }
 
 export interface OppfolgingstilfelleDTO {

--- a/src/api/types/personregisterTypes.ts
+++ b/src/api/types/personregisterTypes.ts
@@ -1,5 +1,4 @@
 import {
-  AktivitetskravStatus,
   ArbeidsuforhetvurderingDTO,
   OppfolgingsoppgaveDTO,
   OppfolgingstilfelleDTO,
@@ -19,11 +18,7 @@ export interface PersonData {
   tildeltVeilederIdent: string;
   dialogmotekandidat?: boolean;
   latestOppfolgingstilfelle?: OppfolgingstilfelleDTO;
-  aktivitetskrav: AktivitetskravStatus | null;
-  aktivitetskravActive: boolean;
-  aktivitetskravVurderingFrist: Date | null;
   harBehandlerdialogUbehandlet: boolean;
-  harAktivitetskravVurderStansUbehandlet: boolean;
   behandlerBerOmBistandUbehandlet: boolean;
   friskmeldingTilArbeidsformidlingFom: Date | null;
   arbeidsuforhetvurdering: ArbeidsuforhetvurderingDTO | null;

--- a/src/components/FristColumn.tsx
+++ b/src/components/FristColumn.tsx
@@ -67,35 +67,35 @@ const oppfolgingsgrunnTekster = (
 
 export const FristColumn = ({ personData }: FristColumnProps) => {
   const {
-    aktivitetskrav,
-    aktivitetskravVurderingFrist,
     oppfolgingsoppgave,
     friskmeldingTilArbeidsformidlingFom,
     arbeidsuforhetvurdering,
     aktivitetskravvurdering,
   } = personData;
   const frister: Frist[] = [];
+  const aktivitetskravStatus = aktivitetskravvurdering?.status;
+  const aktivitetskravVurderingFrist =
+    aktivitetskravvurdering?.vurderinger[0]?.frist;
+  const aktivitetskravVarselFrist =
+    aktivitetskravvurdering?.vurderinger[0]?.varsel?.svarfrist;
   if (
     aktivitetskravvurdering?.vurderinger.length &&
     aktivitetskravvurdering?.vurderinger.length > 0
   ) {
-    const frist = aktivitetskravvurdering.vurderinger[0]?.frist;
-    const varselFrist =
-      aktivitetskravvurdering.vurderinger[0]?.varsel?.svarfrist;
-    frist &&
+    aktivitetskravVurderingFrist &&
       frister.push({
         icon: () => <HourglassTopFilledIcon aria-hidden fontSize="1.5rem" />,
-        date: frist,
+        date: aktivitetskravVurderingFrist,
         tooltip: texts.tooltipAvventer,
       });
-    varselFrist &&
+    aktivitetskravVarselFrist &&
       frister.push({
         icon: () => <HourglassTopFilledIcon aria-hidden fontSize="1.5rem" />,
-        date: varselFrist,
+        date: aktivitetskravVarselFrist,
         tooltip: texts.aktivitetskravvarselFrist,
       });
   } else if (
-    aktivitetskrav === AktivitetskravStatus.AVVENT &&
+    aktivitetskravStatus === AktivitetskravStatus.AVVENT &&
     aktivitetskravVurderingFrist
   ) {
     frister.push({

--- a/src/components/LinkSyfomodiaperson.tsx
+++ b/src/components/LinkSyfomodiaperson.tsx
@@ -13,9 +13,7 @@ export const lenkeTilModia = (personData: PersonData) => {
     personData.dialogmotekandidat;
   const isGoingToOppfolgingsplanOversikt =
     personData.harOppfolgingsplanLPSBistandUbehandlet;
-  const isGoingToAktivitetskrav =
-    personData.aktivitetskravActive ||
-    personData.harAktivitetskravVurderStansUbehandlet;
+  const isGoingToAktivitetskrav = !!personData.aktivitetskravvurdering;
   const isGoingToBehandlerdialog = personData.harBehandlerdialogUbehandlet;
   const isGoingToSykmeldinger = personData.behandlerBerOmBistandUbehandlet;
   const isGoingToArbeidsuforhet = !!personData.arbeidsuforhetvurdering;

--- a/src/data/personoversiktHooks.ts
+++ b/src/data/personoversiktHooks.ts
@@ -22,15 +22,12 @@ const filteredPersonOversiktStatusList = (
 ): PersonOversiktStatusDTO[] => {
   return personOversiktStatusList.filter((personOversiktStatus) => {
     const ubehandletStatus: PersonOversiktUbehandletStatusDTO = {
-      aktivitetskravVurderStansUbehandlet:
-        personOversiktStatus.aktivitetskravVurderStansUbehandlet,
       behandlerdialogUbehandlet: personOversiktStatus.behandlerdialogUbehandlet,
       dialogmotekandidat: personOversiktStatus.dialogmotekandidat,
       dialogmotesvarUbehandlet: personOversiktStatus.dialogmotesvarUbehandlet,
       motebehovUbehandlet: personOversiktStatus.motebehovUbehandlet,
       oppfolgingsplanLPSBistandUbehandlet:
         personOversiktStatus.oppfolgingsplanLPSBistandUbehandlet,
-      aktivitetskravActive: personOversiktStatus.aktivitetskravActive,
       behandlerBerOmBistandUbehandlet:
         personOversiktStatus.behandlerBerOmBistandUbehandlet,
       arbeidsuforhetvurdering: personOversiktStatus.arbeidsuforhetvurdering,

--- a/src/utils/hendelseFilteringUtils.tsx
+++ b/src/utils/hendelseFilteringUtils.tsx
@@ -100,7 +100,9 @@ export const filterOnFrist = (
   }
   const filtered = Object.entries(personregister).filter(([, persondata]) => {
     const frister = [
-      persondata.aktivitetskravVurderingFrist,
+      persondata.arbeidsuforhetvurdering?.varsel?.svarfrist,
+      persondata.aktivitetskravvurdering?.vurderinger[0]?.frist,
+      persondata.aktivitetskravvurdering?.vurderinger[0]?.varsel?.svarfrist,
       persondata.oppfolgingsoppgave?.frist,
       persondata.friskmeldingTilArbeidsformidlingFom,
     ];
@@ -211,12 +213,7 @@ const matchesFilter = (
     case 'isSenOppfolgingChecked':
       return !filters[key] || personData.isAktivSenOppfolgingKandidat;
     case 'isAktivitetskravChecked':
-      return (
-        !filters[key] ||
-        personData.aktivitetskravActive ||
-        personData.harAktivitetskravVurderStansUbehandlet ||
-        personData.aktivitetskravvurdering !== null
-      );
+      return !filters[key] || personData.aktivitetskravvurdering !== null;
     case 'isAktivitetskravVurderStansChecked':
       const isExpiredVarsel =
         !!personData?.aktivitetskravvurdering?.vurderinger[0]?.varsel
@@ -224,11 +221,7 @@ const matchesFilter = (
         isPast(
           personData?.aktivitetskravvurdering.vurderinger[0]?.varsel?.svarfrist
         );
-      return (
-        !filters[key] ||
-        personData.harAktivitetskravVurderStansUbehandlet ||
-        isExpiredVarsel
-      );
+      return !filters[key] || isExpiredVarsel;
   }
 };
 

--- a/src/utils/personDataUtil.ts
+++ b/src/utils/personDataUtil.ts
@@ -50,7 +50,6 @@ export const firstCompanyNameFromPersonData = (
 
 const allFrister = (personData: PersonData): Date[] => {
   return [
-    personData.aktivitetskravVurderingFrist,
     personData.oppfolgingsoppgave?.frist,
     personData.friskmeldingTilArbeidsformidlingFom,
     personData.arbeidsuforhetvurdering?.varsel?.svarfrist,

--- a/src/utils/statusColumnUtils.ts
+++ b/src/utils/statusColumnUtils.ts
@@ -34,8 +34,7 @@ function mapOppfolgingsgrunn(oppfolgingsgrunn: Oppfolgingsgrunn) {
 }
 
 function mapAktivitetskravStatus(personData: PersonData): string {
-  const status =
-    personData?.aktivitetskravvurdering?.status ?? personData.aktivitetskrav;
+  const status = personData?.aktivitetskravvurdering?.status;
   switch (status) {
     case AktivitetskravStatus.NY:
       return '- Ny kandidat';
@@ -72,11 +71,7 @@ function mapArbeidsuforhetStatus(svarfrist: Date | undefined) {
 
 export function getHendelser(personData: PersonData): string[] {
   const hendelser: string[] = [];
-  if (
-    personData.aktivitetskravvurdering ||
-    personData.aktivitetskrav === AktivitetskravStatus.NY ||
-    personData.aktivitetskrav === AktivitetskravStatus.NY_VURDERING
-  ) {
+  if (personData.aktivitetskravvurdering) {
     hendelser.push(`Akt.krav ${mapAktivitetskravStatus(personData)}`);
   }
   if (personData.arbeidsuforhetvurdering) {

--- a/src/utils/toPersondata.ts
+++ b/src/utils/toPersondata.ts
@@ -27,12 +27,7 @@ export const toPersonData = (
       tildeltVeilederIdent: person.veilederIdent || '',
       dialogmotekandidat: person?.dialogmotekandidat,
       latestOppfolgingstilfelle: person.latestOppfolgingstilfelle,
-      aktivitetskrav: person.aktivitetskrav,
-      aktivitetskravActive: person.aktivitetskravActive,
-      aktivitetskravVurderingFrist: person.aktivitetskravVurderingFrist,
       harBehandlerdialogUbehandlet: person.behandlerdialogUbehandlet,
-      harAktivitetskravVurderStansUbehandlet:
-        person.aktivitetskravVurderStansUbehandlet,
       behandlerBerOmBistandUbehandlet: person.behandlerBerOmBistandUbehandlet,
       arbeidsuforhetvurdering: person.arbeidsuforhetvurdering,
       friskmeldingTilArbeidsformidlingFom:

--- a/test/components/FristColumnTest.tsx
+++ b/test/components/FristColumnTest.tsx
@@ -18,11 +18,7 @@ const defaultPersonData: PersonData = {
   harOppfolgingsplanLPSBistandUbehandlet: false,
   tildeltEnhetId: '123',
   tildeltVeilederIdent: '234',
-  aktivitetskrav: null,
-  aktivitetskravActive: false,
-  aktivitetskravVurderingFrist: null,
   harBehandlerdialogUbehandlet: false,
-  harAktivitetskravVurderStansUbehandlet: false,
   behandlerBerOmBistandUbehandlet: false,
   arbeidsuforhetvurdering: null,
   friskmeldingTilArbeidsformidlingFom: null,
@@ -41,25 +37,19 @@ describe('FristColumn', () => {
     expect(screen.queryAllByText(fristFormatRegex)).to.be.empty;
   });
 
-  it('viser ingen frist for person når aktivitetskrav har frist, men ikke AVVENT', () => {
-    const aktivitetskravVurderingFrist = new Date('2023-12-18');
-    const personForhandsvarselMedFrist: PersonData = {
-      ...defaultPersonData,
-      aktivitetskrav: AktivitetskravStatus.FORHANDSVARSEL,
-      aktivitetskravVurderingFrist: aktivitetskravVurderingFrist,
-    };
-    render(<FristColumn personData={personForhandsvarselMedFrist} />);
-
-    expect(screen.queryByText(toReadableDate(aktivitetskravVurderingFrist))).to
-      .not.exist;
-  });
-
   it('viser frist for person når aktivitetskrav AVVENT med frist', () => {
     const aktivitetskravVurderingFrist = new Date('2023-12-18');
     const personAvventerMedFrist: PersonData = {
       ...defaultPersonData,
-      aktivitetskrav: AktivitetskravStatus.AVVENT,
-      aktivitetskravVurderingFrist: aktivitetskravVurderingFrist,
+      aktivitetskravvurdering: {
+        status: AktivitetskravStatus.AVVENT,
+        vurderinger: [
+          {
+            status: AktivitetskravStatus.AVVENT,
+            frist: aktivitetskravVurderingFrist,
+          },
+        ],
+      },
     };
     render(<FristColumn personData={personAvventerMedFrist} />);
 
@@ -97,8 +87,15 @@ describe('FristColumn', () => {
     const friskmeldingTilArbeidsformidlingFom = addWeeks(new Date(), 10);
     const personMedFlereFrister: PersonData = {
       ...defaultPersonData,
-      aktivitetskrav: AktivitetskravStatus.AVVENT,
-      aktivitetskravVurderingFrist: aktivitetskravVurderingFrist,
+      aktivitetskravvurdering: {
+        status: AktivitetskravStatus.AVVENT,
+        vurderinger: [
+          {
+            status: AktivitetskravStatus.AVVENT,
+            frist: aktivitetskravVurderingFrist,
+          },
+        ],
+      },
       oppfolgingsoppgave,
       friskmeldingTilArbeidsformidlingFom,
     };
@@ -167,8 +164,6 @@ describe('FristColumn', () => {
       const svarfristForhandsvarselIkkeVis = new Date('2024-07-17');
       const personMedForhandsvarsel: PersonData = {
         ...defaultPersonData,
-        aktivitetskrav: AktivitetskravStatus.FORHANDSVARSEL,
-        aktivitetskravVurderingFrist: svarfristForhandsvarselIkkeVis,
         aktivitetskravvurdering: {
           status: AktivitetskravStatus.FORHANDSVARSEL,
           vurderinger: [
@@ -194,8 +189,6 @@ describe('FristColumn', () => {
       const aktivitetskravAvventFristIkkeVis = new Date('2024-07-17');
       const personMedForhandsvarsel: PersonData = {
         ...defaultPersonData,
-        aktivitetskrav: AktivitetskravStatus.AVVENT,
-        aktivitetskravVurderingFrist: aktivitetskravAvventFristIkkeVis,
         aktivitetskravvurdering: {
           status: AktivitetskravStatus.AVVENT,
           vurderinger: [

--- a/test/components/NewOversiktTableTest.tsx
+++ b/test/components/NewOversiktTableTest.tsx
@@ -34,11 +34,7 @@ const defaultPersonData: PersonData = {
   harOppfolgingsplanLPSBistandUbehandlet: false,
   tildeltEnhetId: '123',
   tildeltVeilederIdent: '234',
-  aktivitetskrav: null,
-  aktivitetskravActive: false,
-  aktivitetskravVurderingFrist: null,
   harBehandlerdialogUbehandlet: false,
-  harAktivitetskravVurderStansUbehandlet: false,
   behandlerBerOmBistandUbehandlet: false,
   arbeidsuforhetvurdering: null,
   friskmeldingTilArbeidsformidlingFom: null,
@@ -48,13 +44,26 @@ const defaultPersonData: PersonData = {
 };
 const personDataAktivitetskravAvventUtenFrist: PersonData = {
   ...defaultPersonData,
-  aktivitetskrav: AktivitetskravStatus.AVVENT,
-  aktivitetskravActive: true,
-  aktivitetskravVurderingFrist: null,
+  aktivitetskravvurdering: {
+    status: AktivitetskravStatus.AVVENT,
+    vurderinger: [
+      {
+        status: AktivitetskravStatus.AVVENT,
+      },
+    ],
+  },
 };
 const personDataAktivitetskravAvventMedFrist: PersonData = {
   ...personDataAktivitetskravAvventUtenFrist,
-  aktivitetskravVurderingFrist: new Date('2023-04-01'),
+  aktivitetskravvurdering: {
+    status: AktivitetskravStatus.AVVENT,
+    vurderinger: [
+      {
+        status: AktivitetskravStatus.AVVENT,
+        frist: new Date('2023-04-01'),
+      },
+    ],
+  },
 };
 const personWithOppfolgingstilfelle: PersonData = {
   ...defaultPersonData,
@@ -172,7 +181,6 @@ describe('NewOversiktTable', () => {
         harMotebehovUbehandlet: true,
         harOppfolgingsplanLPSBistandUbehandlet: true,
         harBehandlerdialogUbehandlet: true,
-        aktivitetskrav: AktivitetskravStatus.FORHANDSVARSEL,
         aktivitetskravvurdering: {
           status: AktivitetskravStatus.FORHANDSVARSEL,
           vurderinger: [

--- a/test/data/fellesTestdata.ts
+++ b/test/data/fellesTestdata.ts
@@ -2,7 +2,6 @@ import {
   PersonData,
   PersonregisterState,
 } from '@/api/types/personregisterTypes';
-import { AktivitetskravStatus } from '@/api/types/personoversiktTypes';
 
 const veilederIdent = 'Z101010';
 const enhetId = '0316';
@@ -33,8 +32,6 @@ export const personregister: PersonregisterState = {
     skjermingskode: testdata.skjermingskode.ingen,
     markert: false,
     tildeltVeilederIdent: 'Z999999',
-    aktivitetskrav: AktivitetskravStatus.NY,
-    aktivitetskravActive: true,
   } as PersonData,
   [testdata.fnr2]: {
     navn: testdata.navn2,
@@ -43,8 +40,6 @@ export const personregister: PersonregisterState = {
     skjermingskode: testdata.skjermingskode.egenAnsatt,
     markert: false,
     tildeltVeilederIdent: 'Z999999',
-    aktivitetskrav: null,
-    aktivitetskravActive: false,
   } as PersonData,
 };
 

--- a/test/query/personoversiktHooks.test.tsx
+++ b/test/query/personoversiktHooks.test.tsx
@@ -62,10 +62,9 @@ describe('personoversiktHooks tests', () => {
 
     const allPersonsUbehandlet = persons.every((person) => {
       return (
-        person.aktivitetskravActive ||
+        !!person.aktivitetskravvurdering ||
         person.oppfolgingsoppgave ||
         person.behandlerdialogUbehandlet ||
-        person.aktivitetskravVurderStansUbehandlet ||
         person.dialogmotekandidat ||
         person.oppfolgingsplanLPSBistandUbehandlet ||
         person.motebehovUbehandlet ||

--- a/test/utils/hendelseFilteringUtilsTest.ts
+++ b/test/utils/hendelseFilteringUtilsTest.ts
@@ -14,6 +14,7 @@ import { testdata } from '../data/fellesTestdata';
 import { HendelseTypeFilters } from '@/context/filters/filterContextState';
 import { addWeeks, subWeeks } from 'date-fns';
 import { getOppfolgingsoppgave } from '../../mock/data/personoversiktEnhetMock';
+import { AktivitetskravStatus } from '@/api/types/personoversiktTypes';
 
 export const createPersonDataWithName = (name: string): PersonData => {
   return {
@@ -27,11 +28,7 @@ export const createPersonDataWithName = (name: string): PersonData => {
     tildeltVeilederIdent: '234',
     dialogmotekandidat: undefined,
     latestOppfolgingstilfelle: undefined,
-    aktivitetskrav: null,
-    aktivitetskravActive: false,
-    aktivitetskravVurderingFrist: null,
     harBehandlerdialogUbehandlet: false,
-    harAktivitetskravVurderStansUbehandlet: false,
     behandlerBerOmBistandUbehandlet: false,
     arbeidsuforhetvurdering: null,
     friskmeldingTilArbeidsformidlingFom: null,
@@ -199,11 +196,27 @@ describe('hendelseFilteringUtils', () => {
     it('Sorts by aktivitetskrav avventer-frist ascending', () => {
       const personWithEarliestFrist: PersonData = {
         ...createPersonDataWithName('Agnes Agnes'),
-        aktivitetskravVurderingFrist: new Date('2023-12-05'),
+        aktivitetskravvurdering: {
+          status: AktivitetskravStatus.AVVENT,
+          vurderinger: [
+            {
+              status: AktivitetskravStatus.AVVENT,
+              frist: new Date('2023-12-05'),
+            },
+          ],
+        },
       };
       const personWithLatestFrist: PersonData = {
         ...createPersonDataWithName('Bjarne Bjarne'),
-        aktivitetskravVurderingFrist: new Date('2023-12-10'),
+        aktivitetskravvurdering: {
+          status: AktivitetskravStatus.AVVENT,
+          vurderinger: [
+            {
+              status: AktivitetskravStatus.AVVENT,
+              frist: new Date('2023-12-10'),
+            },
+          ],
+        },
       };
       const personWithNoFrist = createPersonDataWithName('Navn Navnesen');
 
@@ -231,11 +244,27 @@ describe('hendelseFilteringUtils', () => {
     it('Sorts by aktivitetskrav avventer-frist descending', () => {
       const personWithEarliestFrist: PersonData = {
         ...createPersonDataWithName('Agnes Agnes'),
-        aktivitetskravVurderingFrist: new Date('2023-12-05'),
+        aktivitetskravvurdering: {
+          status: AktivitetskravStatus.AVVENT,
+          vurderinger: [
+            {
+              status: AktivitetskravStatus.AVVENT,
+              frist: new Date('2023-12-05'),
+            },
+          ],
+        },
       };
       const personWithLatestFrist: PersonData = {
         ...createPersonDataWithName('Bjarne Bjarne'),
-        aktivitetskravVurderingFrist: new Date('2023-12-10'),
+        aktivitetskravvurdering: {
+          status: AktivitetskravStatus.AVVENT,
+          vurderinger: [
+            {
+              status: AktivitetskravStatus.AVVENT,
+              frist: new Date('2023-12-10'),
+            },
+          ],
+        },
       };
       const personWithNoFrist = createPersonDataWithName('Navn Navnesen');
 
@@ -407,7 +436,15 @@ describe('hendelseFilteringUtils', () => {
     it('Sorts by avventer and trenger oppfolging-frist ascending', () => {
       const personWithEarliestFrist: PersonData = {
         ...createPersonDataWithName('Agnes Agnes'),
-        aktivitetskravVurderingFrist: new Date('2023-12-05'),
+        aktivitetskravvurdering: {
+          status: AktivitetskravStatus.AVVENT,
+          vurderinger: [
+            {
+              status: AktivitetskravStatus.AVVENT,
+              frist: new Date('2023-12-05'),
+            },
+          ],
+        },
       };
       const personWithLatestFrist: PersonData = {
         ...createPersonDataWithName('Bjarne Bjarne'),
@@ -439,7 +476,15 @@ describe('hendelseFilteringUtils', () => {
     it('Sorts by avventer and trenger oppfolging-frist descending', () => {
       const personWithEarliestFrist: PersonData = {
         ...createPersonDataWithName('Agnes Agnes'),
-        aktivitetskravVurderingFrist: new Date('2023-12-05'),
+        aktivitetskravvurdering: {
+          status: AktivitetskravStatus.AVVENT,
+          vurderinger: [
+            {
+              status: AktivitetskravStatus.AVVENT,
+              frist: new Date('2023-12-05'),
+            },
+          ],
+        },
       };
       const personWithLatestFrist: PersonData = {
         ...createPersonDataWithName('Bjarne Bjarne'),
@@ -471,12 +516,28 @@ describe('hendelseFilteringUtils', () => {
     it('Sorts ascending by earliest frist per person when person have both frist', () => {
       const personWithEarliestFrist: PersonData = {
         ...createPersonDataWithName('Agnes Agnes'),
-        aktivitetskravVurderingFrist: new Date('2023-12-05'),
+        aktivitetskravvurdering: {
+          status: AktivitetskravStatus.AVVENT,
+          vurderinger: [
+            {
+              status: AktivitetskravStatus.AVVENT,
+              frist: new Date('2023-12-05'),
+            },
+          ],
+        },
         oppfolgingsoppgave: getOppfolgingsoppgave(new Date('2023-12-10')),
       };
       const personWithLatestFrist: PersonData = {
         ...createPersonDataWithName('Bjarne Bjarne'),
-        aktivitetskravVurderingFrist: new Date('2023-12-08'),
+        aktivitetskravvurdering: {
+          status: AktivitetskravStatus.AVVENT,
+          vurderinger: [
+            {
+              status: AktivitetskravStatus.AVVENT,
+              frist: new Date('2023-12-08'),
+            },
+          ],
+        },
         oppfolgingsoppgave: getOppfolgingsoppgave(new Date('2023-12-15')),
       };
 
@@ -500,12 +561,28 @@ describe('hendelseFilteringUtils', () => {
     it('Sorts descending by earliest frist per person when person have both frist', () => {
       const personWithEarliestFrist: PersonData = {
         ...createPersonDataWithName('Agnes Agnes'),
-        aktivitetskravVurderingFrist: new Date('2023-12-05'),
+        aktivitetskravvurdering: {
+          status: AktivitetskravStatus.AVVENT,
+          vurderinger: [
+            {
+              status: AktivitetskravStatus.AVVENT,
+              frist: new Date('2023-12-05'),
+            },
+          ],
+        },
         oppfolgingsoppgave: getOppfolgingsoppgave(new Date('2023-12-10')),
       };
       const personWithLatestFrist: PersonData = {
         ...createPersonDataWithName('Bjarne Bjarne'),
-        aktivitetskravVurderingFrist: new Date('2023-12-08'),
+        aktivitetskravvurdering: {
+          status: AktivitetskravStatus.AVVENT,
+          vurderinger: [
+            {
+              status: AktivitetskravStatus.AVVENT,
+              frist: new Date('2023-12-08'),
+            },
+          ],
+        },
         oppfolgingsoppgave: getOppfolgingsoppgave(new Date('2023-12-15')),
       };
 
@@ -544,7 +621,10 @@ describe('hendelseFilteringUtils', () => {
     it('Return no elements in personregister if no personer matches filter', () => {
       const personDataWithAktivitetskrav: PersonData = {
         ...createPersonDataWithName('Navn Navnesen'),
-        aktivitetskravActive: true,
+        aktivitetskravvurdering: {
+          status: AktivitetskravStatus.NY,
+          vurderinger: [],
+        },
       };
       const personregister: PersonregisterState = {
         '16614407794': personDataWithAktivitetskrav,
@@ -565,12 +645,18 @@ describe('hendelseFilteringUtils', () => {
     it('Return only elements matching all active filters', () => {
       const personDataWithAktivitetskrav: PersonData = {
         ...createPersonDataWithName('Fox Mulder'),
-        aktivitetskravActive: true,
+        aktivitetskravvurdering: {
+          status: AktivitetskravStatus.NY,
+          vurderinger: [],
+        },
       };
       const personDataWithMotebehovAndAktivitetskrav: PersonData = {
         ...createPersonDataWithName('Dana Scully'),
         harMotebehovUbehandlet: true,
-        aktivitetskravActive: true,
+        aktivitetskravvurdering: {
+          status: AktivitetskravStatus.NY,
+          vurderinger: [],
+        },
       };
       const personregister: PersonregisterState = {
         '16614407794': personDataWithAktivitetskrav,
@@ -602,8 +688,15 @@ describe('hendelseFilteringUtils', () => {
       };
       const aktivitetskravVurderingFristBeforeToday: PersonData = {
         ...createPersonDataWithName('Cox Dulder'),
-        aktivitetskravActive: true,
-        aktivitetskravVurderingFrist: oneWeekAgo,
+        aktivitetskravvurdering: {
+          status: AktivitetskravStatus.AVVENT,
+          vurderinger: [
+            {
+              status: AktivitetskravStatus.AVVENT,
+              frist: oneWeekAgo,
+            },
+          ],
+        },
       };
       const oppfolgingsOppgaveFristToday: PersonData = {
         ...createPersonDataWithName('Dox Fulder'),
@@ -611,8 +704,15 @@ describe('hendelseFilteringUtils', () => {
       };
       const aktivitetskravVurderingFristToday: PersonData = {
         ...createPersonDataWithName('Fox Gulder'),
-        aktivitetskravActive: true,
-        aktivitetskravVurderingFrist: today,
+        aktivitetskravvurdering: {
+          status: AktivitetskravStatus.AVVENT,
+          vurderinger: [
+            {
+              status: AktivitetskravStatus.AVVENT,
+              frist: today,
+            },
+          ],
+        },
       };
       const oppfolgingsOppgaveFristFuture: PersonData = {
         ...createPersonDataWithName('Gox Hulder'),
@@ -620,8 +720,15 @@ describe('hendelseFilteringUtils', () => {
       };
       const aktivitetskravVurderingFristFuture: PersonData = {
         ...createPersonDataWithName('Jox Kulder'),
-        aktivitetskravActive: true,
-        aktivitetskravVurderingFrist: oneWeekFromToday,
+        aktivitetskravvurdering: {
+          status: AktivitetskravStatus.AVVENT,
+          vurderinger: [
+            {
+              status: AktivitetskravStatus.AVVENT,
+              frist: oneWeekFromToday,
+            },
+          ],
+        },
       };
       const friskmeldingTilArbeidsformidlingFomFuture: PersonData = {
         ...createPersonDataWithName('Box Bulder'),


### PR DESCRIPTION
Fjerner bruk av redundante aktivitetskrav-felter og utleder disse fra aktivitetskravvurdering-feltet i stedet. Videre kan disse fjernes fra DTOen i syfooversiktsrv.
