### PR TITLE
IS-2696: Add missing manglende medvirkning frist

### DIFF
--- a/src/components/FristColumn.tsx
+++ b/src/components/FristColumn.tsx
@@ -17,6 +17,7 @@ const texts = {
   tooltipOppfolgingsoppgave: 'Oppfølgingsoppgave frist',
   tooltipFriskmeldingTilArbeidsformidling: '§8-5 f.o.m.',
   arbeidsuforhetvarselFrist: '§8-4: Svarfrist forhåndsvarsel',
+  manglendeMedvirkningVarselFrist: '§8-8: Svarfrist forhåndsvarsel',
   aktivitetskravvarselFrist: 'Aktivitetskrav: Svarfrist forhåndsvarsel',
 };
 
@@ -71,6 +72,7 @@ export const FristColumn = ({ personData }: FristColumnProps) => {
     friskmeldingTilArbeidsformidlingFom,
     arbeidsuforhetvurdering,
     aktivitetskravvurdering,
+    manglendeMedvirkning,
   } = personData;
   const frister: Frist[] = [];
   const aktivitetskravStatus = aktivitetskravvurdering?.status;
@@ -127,6 +129,14 @@ export const FristColumn = ({ personData }: FristColumnProps) => {
       icon: () => <HourglassTopFilledIcon aria-hidden fontSize="1.5rem" />,
       date: arbeidsuforhetvurdering.varsel.svarfrist,
       tooltip: texts.arbeidsuforhetvarselFrist,
+    });
+  }
+
+  if (manglendeMedvirkning && manglendeMedvirkning.varsel) {
+    frister.push({
+      icon: () => <HourglassTopFilledIcon aria-hidden fontSize="1.5rem" />,
+      date: manglendeMedvirkning.varsel.svarfrist,
+      tooltip: texts.manglendeMedvirkningVarselFrist,
     });
   }
 

--- a/src/utils/hendelseFilteringUtils.tsx
+++ b/src/utils/hendelseFilteringUtils.tsx
@@ -101,6 +101,7 @@ export const filterOnFrist = (
   const filtered = Object.entries(personregister).filter(([, persondata]) => {
     const frister = [
       persondata.arbeidsuforhetvurdering?.varsel?.svarfrist,
+      persondata.manglendeMedvirkning?.varsel?.svarfrist,
       persondata.aktivitetskravvurdering?.vurderinger[0]?.frist,
       persondata.aktivitetskravvurdering?.vurderinger[0]?.varsel?.svarfrist,
       persondata.oppfolgingsoppgave?.frist,

--- a/src/utils/personDataUtil.ts
+++ b/src/utils/personDataUtil.ts
@@ -53,6 +53,7 @@ const allFrister = (personData: PersonData): Date[] => {
     personData.oppfolgingsoppgave?.frist,
     personData.friskmeldingTilArbeidsformidlingFom,
     personData.arbeidsuforhetvurdering?.varsel?.svarfrist,
+    personData.manglendeMedvirkning?.varsel?.svarfrist,
     personData.aktivitetskravvurdering?.vurderinger[0]?.frist,
     personData.aktivitetskravvurdering?.vurderinger[0]?.varsel?.svarfrist,
   ].filter((frist) => frist) as Date[];

--- a/test/components/FristColumnTest.tsx
+++ b/test/components/FristColumnTest.tsx
@@ -82,6 +82,21 @@ describe('FristColumn', () => {
     ).to.exist;
   });
 
+  it('viser frist for person med manglende medvirkning forhåndsvarsel med svarfrist', () => {
+    const svarfrist = addWeeks(new Date(), 3);
+    const personManglendeMedvirkning: PersonData = {
+      ...defaultPersonData,
+      manglendeMedvirkning: {
+        varsel: {
+          svarfrist: addWeeks(new Date(), 3),
+        },
+      },
+    };
+    render(<FristColumn personData={personManglendeMedvirkning} />);
+
+    expect(screen.getByText(toReadableDate(svarfrist))).to.exist;
+  });
+
   it('viser tidligste frist først når person har flere frister', () => {
     const aktivitetskravVurderingFrist = new Date('2023-12-10');
     const oppfolgingsoppgave = getOppfolgingsoppgave(new Date('2023-12-05'));


### PR DESCRIPTION
Viser eventuell manglende medvirkning forhåndsvarsel svarfrist i fristkolonnen. Fristen var heller ikke tatt med i logikken for filtrering og sortering på frist.
:thought_balloon:  Vi burde nok gjort noe refaktorering av dette frist-opplegget slik at det blir "vanskeligere" å glemme neste gang vi legger til en frist.