### PR TITLE
Use nodejs18-debian12 base-image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,7 @@ COPY dist ./dist
 RUN npm install -g typescript
 RUN tsc --build
 
-FROM gcr.io/distroless/nodejs18-debian11
+FROM gcr.io/distroless/nodejs18-debian12
 WORKDIR /syfooversikt
 
 COPY --from=builder /syfooversikt/package.json ./


### PR DESCRIPTION
Bruker oppdatert base-image (løser noen critical vulnerabilities)
