### PR TITLE
Fjern enhetSyncMode

### DIFF
--- a/src/decorator/decoratorConfig.ts
+++ b/src/decorator/decoratorConfig.ts
@@ -22,7 +22,6 @@ const decoratorConfig = (
       }
     },
     fnrSyncMode: 'writeOnly',
-    enhetSyncMode: 'writeOnly',
     showEnheter: true,
     showSearchArea: true,
     showHotkeys: false,


### PR DESCRIPTION
### Hva har blitt lagt til✨🌈

Når den er satt til `writeOnly` så gjør ikke `fetchActiveEnhetOnMount`
noe, og når ikke enhet er kontrollert fra appen si side så blir aktiv
enhet resatt hver gang siden lastes.
