### PR TITLE
IS-2649: Show content of oppfolgingsoppgave in oversikt

### DIFF
--- a/src/api/types/personoversiktTypes.ts
+++ b/src/api/types/personoversiktTypes.ts
@@ -107,3 +107,19 @@ export enum Oppfolgingsgrunn {
   VURDER_ANNEN_YTELSE = 'VURDER_ANNEN_YTELSE',
   ANNET = 'ANNET',
 }
+
+export const oppfolgingsgrunnToString = {
+  [Oppfolgingsgrunn.TA_KONTAKT_SYKEMELDT]: 'Ta kontakt med den sykmeldte',
+  [Oppfolgingsgrunn.TA_KONTAKT_ARBEIDSGIVER]: 'Ta kontakt med arbeidsgiver',
+  [Oppfolgingsgrunn.TA_KONTAKT_BEHANDLER]: 'Ta kontakt med behandler',
+  [Oppfolgingsgrunn.VURDER_DIALOGMOTE_SENERE]: 'Vurder behov for dialogmøte',
+  [Oppfolgingsgrunn.FOLG_OPP_ETTER_NESTE_SYKMELDING]:
+    'Følg opp etter neste sykmelding',
+  [Oppfolgingsgrunn.VURDER_TILTAK_BEHOV]: 'Vurder behov for tiltak',
+  [Oppfolgingsgrunn.VURDER_ARBEIDSUFORHET]: 'Vurder §8-4 - Arbeidsuførhet',
+  [Oppfolgingsgrunn.FRISKMELDING_TIL_ARBEIDSFORMIDLING]:
+    'Vurder §8-5 - Friskmelding til arbeidsformidling',
+  [Oppfolgingsgrunn.VURDER_14A]: 'Vurder §14a',
+  [Oppfolgingsgrunn.VURDER_ANNEN_YTELSE]: 'Vurder annen ytelse',
+  [Oppfolgingsgrunn.ANNET]: 'Annet',
+};

--- a/src/components/HendelseFilterPanel.tsx
+++ b/src/components/HendelseFilterPanel.tsx
@@ -234,12 +234,12 @@ function CheckboxLabel({ labelText, antallHendelser }: CheckboxLabelProps) {
 export function HendelseFilterPanel({ personRegister }: Props) {
   const { toggles } = useFeatureToggles();
   const { filterState, dispatch: dispatchFilterAction } = useFilters();
-  const { tabType } = useTabType();
+  const { selectedTab } = useTabType();
 
   const checkboxElements = hendelseCheckboxes(
     personRegister,
     filterState,
-    tabType,
+    selectedTab,
     toggles
   ).filter((checkboksElement) => checkboksElement.isVisible);
 

--- a/src/components/NewOversiktTable.tsx
+++ b/src/components/NewOversiktTable.tsx
@@ -4,7 +4,7 @@ import { VeilederColumn } from '@/components/VeilederColumn';
 import { PersonData } from '@/api/types/personregisterTypes';
 import { PersonRadVirksomhetColumn } from '@/components/PersonRadVirksomhetColumn';
 import { OppfolgingstilfelleDTO } from '@/api/types/personoversiktTypes';
-import { FristColumn } from '@/components/FristColumn';
+import { FristDataCell } from '@/components/FristDataCell';
 import { Sorting, SortingKey, useSorting } from '@/hooks/useSorting';
 import { LinkSyfomodiaperson } from '@/components/LinkSyfomodiaperson';
 import { toLastnameFirstnameFormat } from '@/utils/stringUtil';
@@ -14,13 +14,13 @@ import { OverviewTabType } from '@/konstanter';
 import * as Amplitude from '@/utils/amplitude';
 import { EventType } from '@/utils/amplitude';
 
-const getVarighetOppfolgingstilfelle = (
+function getVarighetOppfolgingstilfelle(
   oppfolgingstilfelle: OppfolgingstilfelleDTO | undefined
-): string => {
+): string {
   return oppfolgingstilfelle
     ? `${oppfolgingstilfelle.varighetUker} uker`
     : 'Ukjent';
-};
+}
 
 interface Props {
   personListe: [string, PersonData][];
@@ -30,17 +30,17 @@ interface Props {
   setSorting: (sorting: Sorting) => void;
 }
 
-export const NewOversiktTable = ({
+export function NewOversiktTable({
   personListe,
   selectedRows,
   setSelectedRows,
   sorting,
   setSorting,
-}: Props): ReactElement => {
+}: Props): ReactElement {
   const { columns } = useSorting();
-  const { tabType } = useTabType();
+  const { selectedTab } = useTabType();
 
-  const handleSort = (sortKey: string | undefined) => {
+  function handleSort(sortKey: string | undefined) {
     let direction: 'none' | 'ascending' | 'descending';
     if (sortKey === sorting.orderBy && sorting.direction === 'descending') {
       direction = 'none';
@@ -64,27 +64,27 @@ export const NewOversiktTable = ({
         retning: direction,
       },
     });
-  };
+  }
 
   const allRowsSelected = personListe.length === selectedRows.length;
   const anyRowsSelected = selectedRows.length > 0;
   const isRowSelected = (fnr: string) => selectedRows.includes(fnr);
 
-  const toggleSelectedRow = (fnr: string) => {
+  function toggleSelectedRow(fnr: string) {
     if (isRowSelected(fnr)) {
       setSelectedRows(selectedRows.filter((value) => value !== fnr));
     } else {
       setSelectedRows([...selectedRows, fnr]);
     }
-  };
+  }
 
-  const toggleSelectAllRows = () => {
+  function toggleSelectAllRows() {
     if (anyRowsSelected) {
       setSelectedRows([]);
     } else {
       setSelectedRows(personListe.map(([fnr]) => fnr));
     }
-  };
+  }
 
   return (
     <Table
@@ -109,7 +109,7 @@ export const NewOversiktTable = ({
           {columns
             .filter(
               (column) =>
-                tabType === OverviewTabType.ENHET_OVERVIEW ||
+                selectedTab === OverviewTabType.ENHET_OVERVIEW ||
                 column.sortKey !== 'VEILEDER'
             )
             .map((col, index) => (
@@ -156,7 +156,7 @@ export const NewOversiktTable = ({
             <Table.DataCell textSize="small">
               <PersonRadVirksomhetColumn personData={persondata} />
             </Table.DataCell>
-            {tabType === OverviewTabType.ENHET_OVERVIEW && (
+            {selectedTab === OverviewTabType.ENHET_OVERVIEW && (
               <Table.DataCell textSize="small">
                 <VeilederColumn personData={persondata} />
               </Table.DataCell>
@@ -166,9 +166,7 @@ export const NewOversiktTable = ({
                 persondata.latestOppfolgingstilfelle
               )}
             </Table.DataCell>
-            <Table.DataCell textSize="small">
-              <FristColumn personData={persondata} />
-            </Table.DataCell>
+            <FristDataCell personData={persondata} />
             <Table.DataCell
               textSize="small"
               className="[&>*:not(:last-child)]:mb-1.5"
@@ -184,4 +182,4 @@ export const NewOversiktTable = ({
       </Table.Body>
     </Table>
   );
-};
+}

--- a/src/components/OppfolgingsoppgaveModal.tsx
+++ b/src/components/OppfolgingsoppgaveModal.tsx
@@ -1,0 +1,55 @@
+import React from 'react';
+import { BodyLong, BodyShort, Label, Modal } from '@navikt/ds-react';
+import {
+  oppfolgingsgrunnToString,
+  OppfolgingsoppgaveDTO,
+} from '@/api/types/personoversiktTypes';
+import { toReadableDate } from '@/utils/dateUtils';
+
+const texts = {
+  header: 'Oppfølgingsoppgave',
+  oppfolgingsgrunn: 'Oppfølgingsgrunn',
+  frist: 'Frist',
+};
+
+interface Props {
+  isOpen: boolean;
+  setOpen: (open: boolean) => void;
+  oppfolgingsoppgave: OppfolgingsoppgaveDTO;
+  sykmeldtNavn: string;
+}
+
+export default function OppfolgingsoppgaveModal({
+  isOpen,
+  setOpen,
+  oppfolgingsoppgave,
+  sykmeldtNavn,
+}: Props) {
+  return (
+    <Modal
+      closeOnBackdropClick
+      className="w-full max-w-[50rem]"
+      aria-label="oppfølgingsoppgave"
+      open={isOpen}
+      onClose={() => setOpen(false)}
+      header={{
+        label: sykmeldtNavn,
+        heading: texts.header,
+      }}
+    >
+      <Modal.Body>
+        <Label size="small" as="p">
+          {texts.oppfolgingsgrunn}
+        </Label>
+        <BodyShort className="mb-4">
+          {oppfolgingsgrunnToString[oppfolgingsoppgave.oppfolgingsgrunn]}
+        </BodyShort>
+        <BodyLong className="mb-4">{oppfolgingsoppgave.tekst}</BodyLong>
+        <Label size="small" as="p">
+          {texts.frist}
+        </Label>
+        <BodyShort>{toReadableDate(oppfolgingsoppgave.frist)}</BodyShort>
+      </Modal.Body>
+    </Modal>
+  );
+}

--- a/src/components/Sokeresultat.tsx
+++ b/src/components/Sokeresultat.tsx
@@ -34,7 +34,7 @@ const lagListe = (
 const Sokeresultat = ({ allEvents }: SokeresultatProps) => {
   const tildelVeileder = useTildelVeileder();
   const { filterState } = useFilters();
-  const { tabType } = useTabType();
+  const { selectedTab } = useTabType();
 
   const [markertePersoner, setMarkertePersoner] = useState<string[]>([]);
   const [startItem, setStartItem] = useState(0);
@@ -42,10 +42,10 @@ const Sokeresultat = ({ allEvents }: SokeresultatProps) => {
 
   useEffect(() => {
     setMarkertePersoner([]);
-  }, [tabType]);
+  }, [selectedTab]);
 
   const selectedHendelsetypeFilter =
-    tabType === OverviewTabType.MY_OVERVIEW
+    selectedTab === OverviewTabType.MY_OVERVIEW
       ? {
           ...filterState.selectedHendelseType,
           ufordeltBruker: false,

--- a/src/components/toolbar/AssignVeileder/TildelVeileder.tsx
+++ b/src/components/toolbar/AssignVeileder/TildelVeileder.tsx
@@ -35,11 +35,11 @@ const TildelVeileder = ({
   const [showList, setShowList] = useState(false);
   const [veilederIsChosen, setVeilederIsChosen] = useState(false);
   const [showError, setShowError] = useState(false);
-  const { tabType } = useTabType();
+  const { selectedTab } = useTabType();
 
   useEffect(() => {
     setShowList(false);
-  }, [tabType]);
+  }, [selectedTab]);
 
   const resetStateToDefault = () => {
     setChosenVeilederIdent('');

--- a/src/components/toolbar/Toolbar.tsx
+++ b/src/components/toolbar/Toolbar.tsx
@@ -45,7 +45,7 @@ interface ToolbarProps extends ToolbarWrapperProps {
 }
 
 const Toolbar = (props: ToolbarProps) => {
-  const { tabType } = useTabType();
+  const { selectedTab } = useTabType();
 
   return (
     <ToolbarStyled>
@@ -56,7 +56,7 @@ const Toolbar = (props: ToolbarProps) => {
             handleTildelVeileder={props.buttonHandler}
             handleSelectAll={props.checkAllHandler}
           />
-          {tabType === OverviewTabType.ENHET_OVERVIEW && <SearchVeileder />}
+          {selectedTab === OverviewTabType.ENHET_OVERVIEW && <SearchVeileder />}
         </Element>
         <PaginationContainer
           numberOfItemsTotal={props.numberOfItemsTotal}

--- a/src/containers/Oversikt.tsx
+++ b/src/containers/Oversikt.tsx
@@ -50,7 +50,7 @@ export const Oversikt = ({
 }: OversiktProps) => {
   const aktivVeilederQuery = useAktivVeilederQuery();
   const { filterState } = useFilters();
-  const { tabType } = useTabType();
+  const { selectedTab } = useTabType();
 
   const personData: PersonregisterState = toPersonData(
     personoversiktData,
@@ -58,7 +58,7 @@ export const Oversikt = ({
   );
 
   const eventFilterValue =
-    tabType === OverviewTabType.MY_OVERVIEW
+    selectedTab === OverviewTabType.MY_OVERVIEW
       ? [aktivVeilederQuery.data?.ident || '']
       : filterState.selectedVeilederIdents;
 

--- a/src/context/tab/TabTypeContext.tsx
+++ b/src/context/tab/TabTypeContext.tsx
@@ -5,10 +5,10 @@ import { OverviewTabType } from '@/konstanter';
 type TabTypeProviderProps = { children: React.ReactNode };
 
 export const TabTypeContext = React.createContext<{
-  tabType: OverviewTabType;
+  selectedTab: OverviewTabType;
   setTabType: (tabType: OverviewTabType) => void;
 }>({
-  tabType: OverviewTabType.ENHET_OVERVIEW,
+  selectedTab: OverviewTabType.ENHET_OVERVIEW,
   setTabType: () => undefined,
 });
 
@@ -16,7 +16,7 @@ const TabTypeProvider = ({ children }: TabTypeProviderProps) => {
   const [tabType, setTabType] = useState(OverviewTabType.ENHET_OVERVIEW);
 
   return (
-    <TabTypeContext.Provider value={{ tabType, setTabType }}>
+    <TabTypeContext.Provider value={{ selectedTab: tabType, setTabType }}>
       {children}
     </TabTypeContext.Provider>
   );

--- a/test/components/FristColumnTest.tsx
+++ b/test/components/FristColumnTest.tsx
@@ -1,5 +1,5 @@
 import { render, screen } from '@testing-library/react';
-import { FristColumn } from '@/components/FristColumn';
+import { FristDataCell } from '@/components/FristDataCell';
 import React from 'react';
 import { PersonData, Skjermingskode } from '@/api/types/personregisterTypes';
 import { testdata } from '../data/fellesTestdata';
@@ -33,7 +33,7 @@ const fristFormatRegex = /\b\d{2}\.\d{2}\.\d{4}\b/;
 describe('FristColumn', () => {
   it('viser ingen frister når person har hverken aktivitetskrav AVVENT med frist eller oppfolgingsoppgave med frist', () => {
     const personUtenFrister: PersonData = { ...defaultPersonData };
-    render(<FristColumn personData={personUtenFrister} />);
+    render(<FristDataCell personData={personUtenFrister} />);
 
     expect(screen.queryAllByText(fristFormatRegex)).to.be.empty;
   });
@@ -52,7 +52,7 @@ describe('FristColumn', () => {
         ],
       },
     };
-    render(<FristColumn personData={personAvventerMedFrist} />);
+    render(<FristDataCell personData={personAvventerMedFrist} />);
 
     expect(screen.getByText(toReadableDate(aktivitetskravVurderingFrist))).to
       .exist;
@@ -64,9 +64,10 @@ describe('FristColumn', () => {
       ...defaultPersonData,
       oppfolgingsoppgave,
     };
-    render(<FristColumn personData={personOppfolgingsoppgaveMedFrist} />);
+    render(<FristDataCell personData={personOppfolgingsoppgaveMedFrist} />);
 
-    expect(screen.getByText(toReadableDate(oppfolgingsoppgave.frist))).to.exist;
+    expect(screen.getAllByText(toReadableDate(oppfolgingsoppgave.frist))).to
+      .exist;
   });
 
   it('viser frist for person når friskmelding til arbeidsformidling fom-dato er satt', () => {
@@ -75,7 +76,9 @@ describe('FristColumn', () => {
       ...defaultPersonData,
       friskmeldingTilArbeidsformidlingFom,
     };
-    render(<FristColumn personData={personFriskmeldingTilArbeidsformidling} />);
+    render(
+      <FristDataCell personData={personFriskmeldingTilArbeidsformidling} />
+    );
 
     expect(
       screen.getByText(toReadableDate(friskmeldingTilArbeidsformidlingFom))
@@ -92,7 +95,7 @@ describe('FristColumn', () => {
         },
       },
     };
-    render(<FristColumn personData={personManglendeMedvirkning} />);
+    render(<FristDataCell personData={personManglendeMedvirkning} />);
 
     expect(screen.getByText(toReadableDate(svarfrist))).to.exist;
   });
@@ -116,10 +119,10 @@ describe('FristColumn', () => {
       friskmeldingTilArbeidsformidlingFom,
     };
 
-    render(<FristColumn personData={personMedFlereFrister} />);
+    render(<FristDataCell personData={personMedFlereFrister} />);
 
     const allFrister = screen.getAllByText(fristFormatRegex);
-    expect(allFrister).to.have.length(3);
+    expect(allFrister).to.have.length(4); // 3 frister i oversikten + 1 i modal for oppfølgingsoppgave som finnes i DOM
     expect(allFrister[0]?.textContent).to.eq(
       toReadableDate(oppfolgingsoppgave.frist)
     );
@@ -146,7 +149,7 @@ describe('FristColumn', () => {
           ],
         },
       };
-      render(<FristColumn personData={personMedAvventerFrist} />);
+      render(<FristDataCell personData={personMedAvventerFrist} />);
 
       expect(screen.getByText(toReadableDate(aktivitetskravVurderingFrist))).to
         .exist;
@@ -168,7 +171,7 @@ describe('FristColumn', () => {
           ],
         },
       };
-      render(<FristColumn personData={personMedForhandsvarsel} />);
+      render(<FristDataCell personData={personMedForhandsvarsel} />);
 
       expect(
         screen.getByText(toReadableDate(aktivitetskravSvarfristForhandsvarsel))
@@ -192,7 +195,7 @@ describe('FristColumn', () => {
           ],
         },
       };
-      render(<FristColumn personData={personMedForhandsvarsel} />);
+      render(<FristDataCell personData={personMedForhandsvarsel} />);
 
       expect(screen.getByText(toReadableDate(svarfristForhandsvarselVis))).to
         .exist;
@@ -217,7 +220,7 @@ describe('FristColumn', () => {
           ],
         },
       };
-      render(<FristColumn personData={personMedForhandsvarsel} />);
+      render(<FristDataCell personData={personMedForhandsvarsel} />);
 
       expect(screen.getByText(toReadableDate(aktivitetskravAvventFristVis))).to
         .exist;

--- a/test/components/HendelseTypeFilter.test.tsx
+++ b/test/components/HendelseTypeFilter.test.tsx
@@ -128,7 +128,7 @@ describe('HendelseTypeFilter', () => {
       <NotificationProvider>
         <TabTypeContext.Provider
           value={{
-            tabType: OverviewTabType.MY_OVERVIEW,
+            selectedTab: OverviewTabType.MY_OVERVIEW,
             setTabType: () => void 0,
           }}
         >


### PR DESCRIPTION
### Hva har blitt lagt til✨🌈
- Erstatter ikonet for oppfølgingsoppgave med et klikkbart ikon.
- Dette klikkbare ikonet åpner en modal som viser innholdet i oppfølgingsoppgaven
- Ikonet er bare klikkbart når veileder er i "Min oversikt"

### Screenshots 📸✨

https://github.com/user-attachments/assets/91843326-ed6b-4eff-9c79-f84047816cfa


