### PR TITLE
IS-2791: Edit tooltip oppfølgingsoppgave

### DIFF
--- a/src/components/FristDataCell.tsx
+++ b/src/components/FristDataCell.tsx
@@ -6,10 +6,7 @@ import {
   HourglassTopFilledIcon,
 } from '@navikt/aksel-icons';
 import React, { ReactElement, useState } from 'react';
-import {
-  AktivitetskravStatus,
-  oppfolgingsgrunnToString,
-} from '@/api/types/personoversiktTypes';
+import { AktivitetskravStatus } from '@/api/types/personoversiktTypes';
 import { Button, Table, Tooltip } from '@navikt/ds-react';
 import OppfolgingsoppgaveModal from '@/components/OppfolgingsoppgaveModal';
 import * as Amplitude from '@/utils/amplitude';
@@ -106,7 +103,9 @@ function fristerInfo(
         ),
       date: oppfolgingsoppgave.frist,
       tooltip: `${
-        oppfolgingsgrunnToString[oppfolgingsoppgave.oppfolgingsgrunn]
+        selectedTab === OverviewTabType.MY_OVERVIEW
+          ? 'Åpne oppfølgingsoppgave'
+          : 'Oppfølgingsoppgave frist'
       }`,
     });
   }

--- a/src/mocks/data/personoversiktEnhetMock.ts
+++ b/src/mocks/data/personoversiktEnhetMock.ts
@@ -516,7 +516,7 @@ export const personoversiktEnhetMock: PersonOversiktStatusDTO[] = [
         },
       ],
     },
-    oppfolgingsoppgave: null,
+    oppfolgingsoppgave: getOppfolgingsoppgave(new Date('2024-01-01')),
     latestOppfolgingstilfelle: {
       oppfolgingstilfelleStart: new Date('2022-01-01'),
       oppfolgingstilfelleEnd: new Date('2022-12-31'),


### PR DESCRIPTION
### Hva har blitt lagt til✨🌈
Endre tooltipen til oppfølgingsoppgave slik at den følger samme mønster som de andre tooltipene tilhørende andre hendelser. 

### Screenshots 📸✨
Før:
<img width="1457" alt="Skjermbilde 2024-11-20 kl  13 30 38" src="https://github.com/user-attachments/assets/34439dbe-20e0-4551-9759-cd27ca63f536">

Nå:
![Skjermbilde 2024-11-21 kl  13 09 24](https://github.com/user-attachments/assets/6a85c19b-dfe7-44b4-a3fb-cfe3fbb46313)
![Skjermbilde 2024-11-21 kl  13 10 55](https://github.com/user-attachments/assets/8dc6a496-898c-4627-9bbc-54968f27beaf)




