### PR TITLE
 IS-2995: Endret slik at visning av oppfølgingsoppgaveteksten tar hensyn til whitespace

### DIFF
--- a/src/mocks/data/personoversiktEnhetMock.ts
+++ b/src/mocks/data/personoversiktEnhetMock.ts
@@ -697,7 +697,7 @@ export function getOppfolgingsoppgave(frist?: Date): OppfolgingsoppgaveDTO {
     createdBy: veilederMock.ident,
     updatedAt: new Date(),
     createdAt: new Date(),
-    tekst: 'En tekst',
+    tekst: 'En tekst\n med\n linjeskift',
     oppfolgingsgrunn: getRandomOppfolgingsgrunn(),
     frist: frist ?? null,
   };

--- a/src/sider/oversikt/sokeresultat/oversikttable/fristdatacell/OppfolgingsoppgaveModal.tsx
+++ b/src/sider/oversikt/sokeresultat/oversikttable/fristdatacell/OppfolgingsoppgaveModal.tsx
@@ -44,7 +44,9 @@ export default function OppfolgingsoppgaveModal({
         <BodyShort className="mb-4">
           {oppfolgingsgrunnToString[oppfolgingsoppgave.oppfolgingsgrunn]}
         </BodyShort>
-        <BodyLong className="mb-4">{oppfolgingsoppgave.tekst}</BodyLong>
+        <BodyLong className="mb-4 whitespace-pre-wrap">
+          {oppfolgingsoppgave.tekst}
+        </BodyLong>
         <Label size="small" as="p">
           {texts.frist}
         </Label>


### PR DESCRIPTION
### Hva har blitt lagt til✨🌈
Tekst som inneholder linjeskift vil nå brekke riktig i popup ifm. visning av oppfølgingsoppgaven fra oversikten.

Relatert til: https://github.com/navikt/syfomodiaperson/pull/1602.

### Screenshots 📸✨
![image](https://github.com/user-attachments/assets/1ae65561-b827-4798-b8f7-9d19355b5231)

