### PR TITLE
IS-3030: Fix nullstill valg button

### DIFF
--- a/src/sider/oversikt/filter/HendelseFilter.tsx
+++ b/src/sider/oversikt/filter/HendelseFilter.tsx
@@ -177,10 +177,8 @@ export function HendelseFilter({ personRegister }: Props) {
   const checkboxElements = hendelseCheckboxes(personRegister, filterState);
 
   const onChange = (value: string) => {
-    const newFilterState = updateFilterState(
-      filterState.selectedHendelseType,
-      value as Hendelse
-    );
+    const newFilterState = { ...filterState.selectedHendelseType };
+    updateFilterState(newFilterState, value as Hendelse);
     dispatchFilterAction({
       type: ActionType.SetSelectedHendelseType,
       selectedHendelseType: newFilterState,


### PR DESCRIPTION
### Hva har blitt lagt til✨🌈
- Fikset slik at "nullstill valg" knappen nullstiller alle feltene i venstre filterboks. Problemet var at hendelsesfilteret nullstilte checkbox første gang man prøvde, men ikke flere ganger etter det. Men de andre boksene funket som de skulle. 
- [x] Teste i dev

### Screenshots 📸✨
Før: 

https://github.com/user-attachments/assets/27e863d0-9c8d-44df-b015-4596676b2e2d

Nå:

https://github.com/user-attachments/assets/84608e4b-c171-4c45-b363-5ed1566f1f1f

