### PR TITLE
IS-3036: Add missing oppfolgingsgrunn text

### DIFF
--- a/src/api/types/personoversiktTypes.ts
+++ b/src/api/types/personoversiktTypes.ts
@@ -106,21 +106,61 @@ export enum Oppfolgingsgrunn {
   FRISKMELDING_TIL_ARBEIDSFORMIDLING = 'FRISKMELDING_TIL_ARBEIDSFORMIDLING',
   VURDER_14A = 'VURDER_14A',
   VURDER_ANNEN_YTELSE = 'VURDER_ANNEN_YTELSE',
+  SAMTALE_MED_BRUKER = 'SAMTALE_MED_BRUKER',
   ANNET = 'ANNET',
 }
 
-export const oppfolgingsgrunnToString = {
-  [Oppfolgingsgrunn.TA_KONTAKT_SYKEMELDT]: 'Ta kontakt med den sykmeldte',
-  [Oppfolgingsgrunn.TA_KONTAKT_ARBEIDSGIVER]: 'Ta kontakt med arbeidsgiver',
-  [Oppfolgingsgrunn.TA_KONTAKT_BEHANDLER]: 'Ta kontakt med behandler',
-  [Oppfolgingsgrunn.VURDER_DIALOGMOTE_SENERE]: 'Vurder behov for dialogmøte',
-  [Oppfolgingsgrunn.FOLG_OPP_ETTER_NESTE_SYKMELDING]:
-    'Følg opp etter neste sykmelding',
-  [Oppfolgingsgrunn.VURDER_TILTAK_BEHOV]: 'Vurder behov for tiltak',
-  [Oppfolgingsgrunn.VURDER_ARBEIDSUFORHET]: 'Vurder §8-4 - Arbeidsuførhet',
-  [Oppfolgingsgrunn.FRISKMELDING_TIL_ARBEIDSFORMIDLING]:
-    'Vurder §8-5 - Friskmelding til arbeidsformidling',
-  [Oppfolgingsgrunn.VURDER_14A]: 'Vurder §14a',
-  [Oppfolgingsgrunn.VURDER_ANNEN_YTELSE]: 'Vurder annen ytelse',
-  [Oppfolgingsgrunn.ANNET]: 'Annet',
+type OppfolgingsgrunnText = { long: string; short: string };
+export const oppfolgingsgrunnToString: Record<
+  Oppfolgingsgrunn,
+  OppfolgingsgrunnText
+> = {
+  [Oppfolgingsgrunn.TA_KONTAKT_SYKEMELDT]: {
+    long: 'Ta kontakt med den sykmeldte',
+    short: 'Kontakt sykmeldt',
+  },
+  [Oppfolgingsgrunn.TA_KONTAKT_ARBEIDSGIVER]: {
+    long: 'Ta kontakt med arbeidsgiver',
+    short: 'Kontakt arbeidsgiver',
+  },
+  [Oppfolgingsgrunn.TA_KONTAKT_BEHANDLER]: {
+    long: 'Ta kontakt med behandler',
+    short: 'Kontakt behandler',
+  },
+  [Oppfolgingsgrunn.VURDER_DIALOGMOTE_SENERE]: {
+    long: 'Vurder behov for dialogmøte',
+    short: 'Vurder dialogmøte',
+  },
+  [Oppfolgingsgrunn.FOLG_OPP_ETTER_NESTE_SYKMELDING]: {
+    long: 'Følg opp etter neste sykmelding',
+    short: 'Følg opp etter sykmelding',
+  },
+  [Oppfolgingsgrunn.VURDER_TILTAK_BEHOV]: {
+    long: 'Vurder behov for tiltak',
+    short: 'Vurder tiltak',
+  },
+  [Oppfolgingsgrunn.VURDER_ARBEIDSUFORHET]: {
+    long: 'Vurder §8-4 - Arbeidsuførhet',
+    short: 'Vurder §8-4',
+  },
+  [Oppfolgingsgrunn.FRISKMELDING_TIL_ARBEIDSFORMIDLING]: {
+    long: 'Vurder §8-5 - Friskmelding til arbeidsformidling',
+    short: 'Vurder §8-5',
+  },
+  [Oppfolgingsgrunn.VURDER_14A]: {
+    long: 'Vurder §14a',
+    short: 'Vurder §14a',
+  },
+  [Oppfolgingsgrunn.VURDER_ANNEN_YTELSE]: {
+    long: 'Vurder annen ytelse',
+    short: 'Vurder annen ytelse',
+  },
+  [Oppfolgingsgrunn.SAMTALE_MED_BRUKER]: {
+    long: 'Samtale med bruker',
+    short: 'Samtale med bruker',
+  },
+  [Oppfolgingsgrunn.ANNET]: {
+    long: 'Annet',
+    short: 'Annet',
+  },
 };

--- a/src/sider/oversikt/sokeresultat/oversikttable/fristdatacell/OppfolgingsoppgaveModal.tsx
+++ b/src/sider/oversikt/sokeresultat/oversikttable/fristdatacell/OppfolgingsoppgaveModal.tsx
@@ -42,7 +42,7 @@ export default function OppfolgingsoppgaveModal({
           {texts.oppfolgingsgrunn}
         </Label>
         <BodyShort className="mb-4">
-          {oppfolgingsgrunnToString[oppfolgingsoppgave.oppfolgingsgrunn]}
+          {oppfolgingsgrunnToString[oppfolgingsoppgave.oppfolgingsgrunn]?.long}
         </BodyShort>
         <BodyLong className="mb-4 whitespace-pre-wrap">
           {oppfolgingsoppgave.tekst}

--- a/src/utils/hendelseColumnUtils.ts
+++ b/src/utils/hendelseColumnUtils.ts
@@ -1,41 +1,12 @@
 import {
   AktivitetskravStatus,
   OnskerOppfolging,
-  Oppfolgingsgrunn,
+  oppfolgingsgrunnToString,
   SenOppfolgingKandidatDTO,
 } from '@/api/types/personoversiktTypes';
 import { PersonData } from '@/api/types/personregisterTypes';
 import { ManglendeMedvirkningDTO } from '@/api/types/manglendeMedvirkningDTO';
 import { isPast } from '@/utils/dateUtils';
-
-function mapOppfolgingsgrunn(oppfolgingsgrunn: Oppfolgingsgrunn) {
-  switch (oppfolgingsgrunn) {
-    case Oppfolgingsgrunn.ANNET:
-      return 'Annet';
-    case Oppfolgingsgrunn.FOLG_OPP_ETTER_NESTE_SYKMELDING:
-      return 'Følg opp etter sykmelding';
-    case Oppfolgingsgrunn.FRISKMELDING_TIL_ARBEIDSFORMIDLING:
-      return 'Vurder § 8-5';
-    case Oppfolgingsgrunn.TA_KONTAKT_ARBEIDSGIVER:
-      return 'Kontakt arbeidsgiver';
-    case Oppfolgingsgrunn.TA_KONTAKT_BEHANDLER:
-      return 'Kontakt behandler';
-    case Oppfolgingsgrunn.TA_KONTAKT_SYKEMELDT:
-      return 'Kontakt sykmeldt';
-    case Oppfolgingsgrunn.VURDER_14A:
-      return 'Vurder § 14a';
-    case Oppfolgingsgrunn.VURDER_ANNEN_YTELSE:
-      return 'Vurder annen ytelse';
-    case Oppfolgingsgrunn.VURDER_ARBEIDSUFORHET:
-      return 'Vurder § 8-4';
-    case Oppfolgingsgrunn.VURDER_DIALOGMOTE_SENERE:
-      return 'Vurder dialogmøte';
-    case Oppfolgingsgrunn.VURDER_TILTAK_BEHOV:
-      return 'Vurder tiltak';
-    default:
-      return '';
-  }
-}
 
 function mapAktivitetskravStatus(personData: PersonData): string {
   const status = personData?.aktivitetskravvurdering?.status;
@@ -130,11 +101,10 @@ export function getHendelser(personData: PersonData): string[] {
     hendelser.push('Friskmelding til arbeidsformidling');
   }
   if (personData.oppfolgingsoppgave) {
-    hendelser.push(
-      `Oppf.oppgave - ${mapOppfolgingsgrunn(
-        personData.oppfolgingsoppgave.oppfolgingsgrunn
-      )}`
-    );
+    const oppfolgingsgrunn =
+      oppfolgingsgrunnToString[personData.oppfolgingsoppgave.oppfolgingsgrunn]
+        ?.short;
+    hendelser.push(`Oppf.oppgave - ${oppfolgingsgrunn ?? ''}`);
   }
   if (personData.harOppfolgingsplanLPSBistandUbehandlet) {
     hendelser.push('Oppfølgingsplan'); //TODO: Hva skal denne egt gjøre?


### PR DESCRIPTION
### Hva har blitt lagt til✨🌈

Legger til manglende tekst(er) for oppfolgingsgrunn `SAMTALE_MED_BRUKER`.
Legger tekst-variantene (én for modalen og én for hendelse-kolonnen) sammen med enumen og gjør slik at koden ikke kompilerer om man legger inn ny grunn uten å angi tekster.

### Screenshots 📸✨

![image](https://github.com/user-attachments/assets/1312a724-1ff6-4467-bd5f-d2b4e2e16c0c)
