### PR TITLE
IS-2838: move and log nullstill valg button

### DIFF
--- a/src/sider/oversikt/Oversikt.tsx
+++ b/src/sider/oversikt/Oversikt.tsx
@@ -72,7 +72,6 @@ export default function Oversikt({
   return (
     <OversiktContainerInnhold>
       <SokeresultatFiltre>
-        <ClearFiltersButton />
         <Box
           borderRadius="medium"
           background="surface-default"
@@ -88,6 +87,7 @@ export default function Oversikt({
           <HendelseFilter personRegister={allEvents.value} />
 
           <PersonFilter personregister={personData} />
+          <ClearFiltersButton />
         </Box>
       </SokeresultatFiltre>
 

--- a/src/sider/oversikt/filter/ClearFiltersButton.tsx
+++ b/src/sider/oversikt/filter/ClearFiltersButton.tsx
@@ -3,6 +3,8 @@ import { useFilters } from '@/context/filters/FilterContext';
 import { ActionType } from '@/context/filters/filterContextActions';
 import { Button } from '@navikt/ds-react';
 import { TrashIcon } from '@navikt/aksel-icons';
+import * as Amplitude from '@/utils/amplitude';
+import { EventType } from '@/utils/amplitude';
 
 const texts = {
   nullstill: 'Nullstill valg',
@@ -11,16 +13,27 @@ const texts = {
 export const ClearFiltersButton = (): ReactElement => {
   const { dispatch: dispatchFilterAction } = useFilters();
 
+  function handleButtonClick() {
+    dispatchFilterAction({
+      type: ActionType.ResetFilters,
+    });
+
+    Amplitude.logEvent({
+      type: EventType.ButtonClick,
+      data: {
+        url: window.location.href,
+        tekst: 'Nullstill valg',
+      },
+    });
+  }
+
   return (
     <Button
       variant="tertiary"
       size="small"
       icon={<TrashIcon title="a11y-title" fontSize="1.5rem" />}
-      onClick={() => {
-        dispatchFilterAction({
-          type: ActionType.ResetFilters,
-        });
-      }}
+      onClick={handleButtonClick}
+      className="max-w-max"
     >
       {texts.nullstill}
     </Button>


### PR DESCRIPTION
### Hva har blitt lagt til✨🌈
- Flyttet nullstill valg knapp der den hører hjemme, inni selve filterboksen. Plassert nederst pga ui mønster. Dette gjør også at filtrene dyttes opp i synsfeltet og blir lettere tilgjengelig. 
- Måler bruk av nullstill knappen

### Screenshots 📸✨
![image](https://github.com/user-attachments/assets/ca3c52cf-0a6d-48ed-aae9-46d494220872)
