### PR TITLE
IS-3068: Lagt til visning av årsaker hvis status for aktivitetskravvurdering er AVVENT

### DIFF
--- a/src/api/types/aktivitetskravDTO.ts
+++ b/src/api/types/aktivitetskravDTO.ts
@@ -1,4 +1,7 @@
-import { AktivitetskravStatus } from '@/api/types/personoversiktTypes';
+import {
+  AktivitetskravStatus,
+  AvventVurderingArsak,
+} from '@/api/types/personoversiktTypes';
 
 export interface AktivitetskravDTO {
   status: AktivitetskravStatus;
@@ -9,6 +12,7 @@ interface AktivitetskravvurderingDTO {
   status: AktivitetskravStatus;
   frist?: Date;
   varsel?: AktivitetskravVarselDTO;
+  arsaker: AvventVurderingArsak[];
 }
 
 interface AktivitetskravVarselDTO {

--- a/src/api/types/personoversiktTypes.ts
+++ b/src/api/types/personoversiktTypes.ts
@@ -23,6 +23,31 @@ export enum AktivitetskravStatus {
   NY_VURDERING = 'NY_VURDERING',
 }
 
+export type VurderingArsakTexts = {
+  [key in AvventVurderingArsak]?: string;
+};
+
+export enum AvventVurderingArsak {
+  OPPFOLGINGSPLAN_ARBEIDSGIVER = 'OPPFOLGINGSPLAN_ARBEIDSGIVER',
+  INFORMASJON_BEHANDLER = 'INFORMASJON_BEHANDLER',
+  INFORMASJON_SYKMELDT = 'INFORMASJON_SYKMELDT',
+  DROFTES_MED_ROL = 'DROFTES_MED_ROL',
+  DROFTES_INTERNT = 'DROFTES_INTERNT',
+  ANNET = 'ANNET',
+}
+
+export const avventVurderingArsakTexts: VurderingArsakTexts = {
+  [AvventVurderingArsak.OPPFOLGINGSPLAN_ARBEIDSGIVER]:
+    'Har bedt om oppfølgingsplan fra arbeidsgiver',
+  [AvventVurderingArsak.INFORMASJON_BEHANDLER]:
+    'Har bedt om mer informasjon fra behandler',
+  [AvventVurderingArsak.INFORMASJON_SYKMELDT]:
+    'Har bedt om informasjon fra den sykemeldte',
+  [AvventVurderingArsak.DROFTES_MED_ROL]: 'Drøftes med ROL',
+  [AvventVurderingArsak.DROFTES_INTERNT]: 'Drøftes internt',
+  [AvventVurderingArsak.ANNET]: 'Annet',
+};
+
 export interface PersonOversiktUbehandletStatusDTO {
   motebehovUbehandlet: boolean | null;
   dialogmotesvarUbehandlet: boolean;

--- a/src/api/types/personoversiktTypes.ts
+++ b/src/api/types/personoversiktTypes.ts
@@ -23,10 +23,6 @@ export enum AktivitetskravStatus {
   NY_VURDERING = 'NY_VURDERING',
 }
 
-export type VurderingArsakTexts = {
-  [key in AvventVurderingArsak]?: string;
-};
-
 export enum AvventVurderingArsak {
   OPPFOLGINGSPLAN_ARBEIDSGIVER = 'OPPFOLGINGSPLAN_ARBEIDSGIVER',
   INFORMASJON_BEHANDLER = 'INFORMASJON_BEHANDLER',
@@ -36,7 +32,7 @@ export enum AvventVurderingArsak {
   ANNET = 'ANNET',
 }
 
-export const avventVurderingArsakTexts: VurderingArsakTexts = {
+export const avventVurderingArsakTexts: Record<AvventVurderingArsak, string> = {
   [AvventVurderingArsak.OPPFOLGINGSPLAN_ARBEIDSGIVER]:
     'Har bedt om oppfølgingsplan fra arbeidsgiver',
   [AvventVurderingArsak.INFORMASJON_BEHANDLER]:

--- a/src/mocks/data/personoversiktEnhetMock.ts
+++ b/src/mocks/data/personoversiktEnhetMock.ts
@@ -1,5 +1,6 @@
 import {
   AktivitetskravStatus,
+  AvventVurderingArsak,
   MoteStatusType,
   OnskerOppfolging,
   Oppfolgingsgrunn,
@@ -57,6 +58,7 @@ export const personoversiktEnhetMock: PersonOversiktStatusDTO[] = [
         {
           status: AktivitetskravStatus.AVVENT,
           frist: dayjs(new Date()).add(-2, 'day').toDate(),
+          arsaker: [],
         },
       ],
     },
@@ -82,6 +84,7 @@ export const personoversiktEnhetMock: PersonOversiktStatusDTO[] = [
           varsel: {
             svarfrist: new Date('2024-12-01'),
           },
+          arsaker: [],
         },
       ],
     },
@@ -130,6 +133,7 @@ export const personoversiktEnhetMock: PersonOversiktStatusDTO[] = [
         {
           status: AktivitetskravStatus.AVVENT,
           frist: new Date('2022-12-08'),
+          arsaker: [],
         },
       ],
     },
@@ -162,6 +166,7 @@ export const personoversiktEnhetMock: PersonOversiktStatusDTO[] = [
         {
           status: AktivitetskravStatus.AVVENT,
           frist: new Date('2022-12-10'),
+          arsaker: [AvventVurderingArsak.ANNET],
         },
       ],
     },
@@ -205,6 +210,10 @@ export const personoversiktEnhetMock: PersonOversiktStatusDTO[] = [
         {
           status: AktivitetskravStatus.AVVENT,
           frist: new Date('2022-12-10'),
+          arsaker: [
+            AvventVurderingArsak.INFORMASJON_BEHANDLER,
+            AvventVurderingArsak.ANNET,
+          ],
         },
       ],
     },
@@ -245,6 +254,7 @@ export const personoversiktEnhetMock: PersonOversiktStatusDTO[] = [
         {
           status: AktivitetskravStatus.AVVENT,
           frist: new Date('2023-04-01'),
+          arsaker: [],
         },
       ],
     },
@@ -279,6 +289,7 @@ export const personoversiktEnhetMock: PersonOversiktStatusDTO[] = [
         {
           status: AktivitetskravStatus.AVVENT,
           frist: new Date('2023-12-10'),
+          arsaker: [],
         },
       ],
     },
@@ -359,6 +370,7 @@ export const personoversiktEnhetMock: PersonOversiktStatusDTO[] = [
         {
           status: AktivitetskravStatus.AVVENT,
           frist: new Date('2022-12-10'),
+          arsaker: [],
         },
       ],
     },
@@ -535,6 +547,10 @@ export const personoversiktEnhetMock: PersonOversiktStatusDTO[] = [
         {
           status: AktivitetskravStatus.AVVENT,
           frist: new Date('2022-12-10'),
+          arsaker: [
+            AvventVurderingArsak.OPPFOLGINGSPLAN_ARBEIDSGIVER,
+            AvventVurderingArsak.INFORMASJON_BEHANDLER,
+          ],
         },
       ],
     },
@@ -566,6 +582,10 @@ export const personoversiktEnhetMock: PersonOversiktStatusDTO[] = [
         {
           status: AktivitetskravStatus.AVVENT,
           frist: new Date('2022-12-20'),
+          arsaker: [
+            AvventVurderingArsak.ANNET,
+            AvventVurderingArsak.INFORMASJON_SYKMELDT,
+          ],
         },
       ],
     },

--- a/src/utils/hendelseColumnUtils.ts
+++ b/src/utils/hendelseColumnUtils.ts
@@ -1,5 +1,6 @@
 import {
   AktivitetskravStatus,
+  avventVurderingArsakTexts,
   OnskerOppfolging,
   oppfolgingsgrunnToString,
   SenOppfolgingKandidatDTO,
@@ -7,6 +8,20 @@ import {
 import { PersonData } from '@/api/types/personregisterTypes';
 import { ManglendeMedvirkningDTO } from '@/api/types/manglendeMedvirkningDTO';
 import { isPast } from '@/utils/dateUtils';
+
+function getAvventarsaker(personData: PersonData): string {
+  const arsaker = personData.aktivitetskravvurdering?.vurderinger[0]?.arsaker;
+
+  if (arsaker === undefined || arsaker.length == 0) {
+    return '';
+  }
+
+  return ` (${arsaker
+    .sort()
+    .reverse()
+    .map((arsak) => avventVurderingArsakTexts[arsak])
+    .join(', ')})`;
+}
 
 function mapAktivitetskravStatus(personData: PersonData): string {
   const status = personData?.aktivitetskravvurdering?.status;
@@ -16,7 +31,7 @@ function mapAktivitetskravStatus(personData: PersonData): string {
     case AktivitetskravStatus.NY_VURDERING:
       return '- Ny vurdering';
     case AktivitetskravStatus.AVVENT:
-      return '- Avventer';
+      return '- Avventer' + getAvventarsaker(personData);
     case AktivitetskravStatus.FORHANDSVARSEL:
       const svarfrist =
         personData.aktivitetskravvurdering?.vurderinger[0]?.varsel?.svarfrist;
@@ -73,7 +88,7 @@ function mapSenOppfolgingStatus(
 export function getHendelser(personData: PersonData): string[] {
   const hendelser: string[] = [];
   if (personData.aktivitetskravvurdering) {
-    hendelser.push(`Akt.krav ${mapAktivitetskravStatus(personData)}`);
+    hendelser.push(`Aktivitetskrav ${mapAktivitetskravStatus(personData)}`);
   }
   if (personData.arbeidsuforhetvurdering) {
     hendelser.push(

--- a/test/components/FristColumnTest.tsx
+++ b/test/components/FristColumnTest.tsx
@@ -57,6 +57,7 @@ describe('FristColumn', () => {
           {
             status: AktivitetskravStatus.AVVENT,
             frist: aktivitetskravVurderingFrist,
+            arsaker: [],
           },
         ],
       },
@@ -119,6 +120,7 @@ describe('FristColumn', () => {
           {
             status: AktivitetskravStatus.AVVENT,
             frist: aktivitetskravVurderingFrist,
+            arsaker: [],
           },
         ],
       },
@@ -152,6 +154,7 @@ describe('FristColumn', () => {
             {
               status: AktivitetskravStatus.AVVENT,
               frist: aktivitetskravVurderingFrist,
+              arsaker: [],
             },
           ],
         },
@@ -174,6 +177,7 @@ describe('FristColumn', () => {
               varsel: {
                 svarfrist: aktivitetskravSvarfristForhandsvarsel,
               },
+              arsaker: [],
             },
           ],
         },
@@ -198,6 +202,7 @@ describe('FristColumn', () => {
               varsel: {
                 svarfrist: svarfristForhandsvarselVis,
               },
+              arsaker: [],
             },
           ],
         },
@@ -223,6 +228,7 @@ describe('FristColumn', () => {
               varsel: {
                 svarfrist: aktivitetskravAvventFristVis,
               },
+              arsaker: [],
             },
           ],
         },

--- a/test/components/NewOversiktTableTest.tsx
+++ b/test/components/NewOversiktTableTest.tsx
@@ -17,6 +17,7 @@ import {
 } from '@/api/types/personregisterTypes';
 import {
   AktivitetskravStatus,
+  AvventVurderingArsak,
   OnskerOppfolging,
   Oppfolgingsgrunn,
 } from '@/api/types/personoversiktTypes';
@@ -53,6 +54,7 @@ const personDataAktivitetskravAvventUtenFrist: PersonData = {
     vurderinger: [
       {
         status: AktivitetskravStatus.AVVENT,
+        arsaker: [],
       },
     ],
   },
@@ -65,6 +67,7 @@ const personDataAktivitetskravAvventMedFrist: PersonData = {
       {
         status: AktivitetskravStatus.AVVENT,
         frist: new Date('2023-04-01'),
+        arsaker: [],
       },
     ],
   },
@@ -194,6 +197,7 @@ describe('NewOversiktTable', () => {
               varsel: {
                 svarfrist: dayjs().add(-1, 'day').toDate(),
               },
+              arsaker: [],
             },
           ],
         },
@@ -232,7 +236,7 @@ describe('NewOversiktTable', () => {
     expect(screen.getByText('Dialogmøte - Nytt svar')).to.exist;
     expect(screen.getByText('Dialogmøte - Kandidat')).to.exist;
     expect(screen.getByText('Dialogmøte - Møtebehov')).to.exist;
-    expect(screen.getByText('Akt.krav - Forhåndsvarsel utløpt')).to.exist;
+    expect(screen.getByText('Aktivitetskrav - Forhåndsvarsel utløpt')).to.exist;
     expect(screen.getByText('Arbeidsuførhet - Forhåndsvarsel sendt')).to.exist;
     expect(screen.getByText('Friskmelding til arbeidsformidling')).to.exist;
     expect(screen.getByText('Oppf.oppgave - Kontakt sykmeldt')).to.exist;
@@ -243,5 +247,61 @@ describe('NewOversiktTable', () => {
       .to.exist;
     expect(screen.getByText('Manglende medvirkning - Forhåndsvarsel utløpt')).to
       .exist;
+  });
+
+  it('Viser årsaker for aktivitetskravvurdering ved status AVVENT for flere personer', () => {
+    renderOversikt({
+      [testdata.fnr1]: {
+        ...defaultPersonData,
+        aktivitetskravvurdering: {
+          status: AktivitetskravStatus.AVVENT,
+          vurderinger: [
+            {
+              status: AktivitetskravStatus.AVVENT,
+              arsaker: [AvventVurderingArsak.INFORMASJON_BEHANDLER],
+            },
+          ],
+        },
+      },
+      [testdata.fnr2]: {
+        ...defaultPersonData,
+        aktivitetskravvurdering: {
+          status: AktivitetskravStatus.AVVENT,
+          vurderinger: [
+            {
+              status: AktivitetskravStatus.AVVENT,
+              arsaker: [
+                AvventVurderingArsak.INFORMASJON_SYKMELDT,
+                AvventVurderingArsak.ANNET,
+              ],
+            },
+          ],
+        },
+      },
+      [testdata.fnr3]: {
+        ...defaultPersonData,
+        aktivitetskravvurdering: {
+          status: AktivitetskravStatus.AVVENT,
+          vurderinger: [
+            {
+              status: AktivitetskravStatus.AVVENT,
+              arsaker: [],
+            },
+          ],
+        },
+      },
+    });
+
+    expect(
+      screen.getByText(
+        'Aktivitetskrav - Avventer (Har bedt om informasjon fra den sykemeldte, Annet)'
+      )
+    ).to.exist;
+    expect(
+      screen.getByText(
+        'Aktivitetskrav - Avventer (Har bedt om mer informasjon fra behandler)'
+      )
+    ).to.exist;
+    expect(screen.getByText('Aktivitetskrav - Avventer')).to.exist;
   });
 });

--- a/test/utils/hendelseFilteringUtilsTest.ts
+++ b/test/utils/hendelseFilteringUtilsTest.ts
@@ -203,6 +203,7 @@ describe('hendelseFilteringUtils', () => {
             {
               status: AktivitetskravStatus.AVVENT,
               frist: new Date('2023-12-05'),
+              arsaker: [],
             },
           ],
         },
@@ -215,6 +216,7 @@ describe('hendelseFilteringUtils', () => {
             {
               status: AktivitetskravStatus.AVVENT,
               frist: new Date('2023-12-10'),
+              arsaker: [],
             },
           ],
         },
@@ -251,6 +253,7 @@ describe('hendelseFilteringUtils', () => {
             {
               status: AktivitetskravStatus.AVVENT,
               frist: new Date('2023-12-05'),
+              arsaker: [],
             },
           ],
         },
@@ -263,6 +266,7 @@ describe('hendelseFilteringUtils', () => {
             {
               status: AktivitetskravStatus.AVVENT,
               frist: new Date('2023-12-10'),
+              arsaker: [],
             },
           ],
         },
@@ -443,6 +447,7 @@ describe('hendelseFilteringUtils', () => {
             {
               status: AktivitetskravStatus.AVVENT,
               frist: new Date('2023-12-05'),
+              arsaker: [],
             },
           ],
         },
@@ -483,6 +488,7 @@ describe('hendelseFilteringUtils', () => {
             {
               status: AktivitetskravStatus.AVVENT,
               frist: new Date('2023-12-05'),
+              arsaker: [],
             },
           ],
         },
@@ -523,6 +529,7 @@ describe('hendelseFilteringUtils', () => {
             {
               status: AktivitetskravStatus.AVVENT,
               frist: new Date('2023-12-05'),
+              arsaker: [],
             },
           ],
         },
@@ -536,6 +543,7 @@ describe('hendelseFilteringUtils', () => {
             {
               status: AktivitetskravStatus.AVVENT,
               frist: new Date('2023-12-08'),
+              arsaker: [],
             },
           ],
         },
@@ -568,6 +576,7 @@ describe('hendelseFilteringUtils', () => {
             {
               status: AktivitetskravStatus.AVVENT,
               frist: new Date('2023-12-05'),
+              arsaker: [],
             },
           ],
         },
@@ -581,6 +590,7 @@ describe('hendelseFilteringUtils', () => {
             {
               status: AktivitetskravStatus.AVVENT,
               frist: new Date('2023-12-08'),
+              arsaker: [],
             },
           ],
         },
@@ -694,6 +704,7 @@ describe('hendelseFilteringUtils', () => {
             {
               status: AktivitetskravStatus.AVVENT,
               frist: oneWeekAgo,
+              arsaker: [],
             },
           ],
         },
@@ -710,6 +721,7 @@ describe('hendelseFilteringUtils', () => {
             {
               status: AktivitetskravStatus.AVVENT,
               frist: today,
+              arsaker: [],
             },
           ],
         },
@@ -726,6 +738,7 @@ describe('hendelseFilteringUtils', () => {
             {
               status: AktivitetskravStatus.AVVENT,
               frist: oneWeekFromToday,
+              arsaker: [],
             },
           ],
         },


### PR DESCRIPTION
### Hva har blitt lagt til✨🌈
Lagt til årsaker i parentes hvis aktivitetskravstatus er `AVVENT`. Det er lagt inn synkende sortering på årsaker ettersom jeg tenker det ser penest ut hvis årsaken `ANNET` kommer sist, både visuelt og at det er årsaken som er minst relevant.

### Screenshots 📸✨
![image](https://github.com/user-attachments/assets/3c1ff10b-2cf3-48f7-aa61-40921fd7040e)
