### PR TITLE
IS-2892: Lagt til virksomhet-kolonne i søkeresultat

### DIFF
--- a/src/mocks/data/personoversiktEnhetMock.ts
+++ b/src/mocks/data/personoversiktEnhetMock.ts
@@ -43,6 +43,21 @@ export const personoversiktEnhetMock: PersonOversiktStatusDTO[] = [
         svarfrist: new Date('2026-12-01T10:12:05.913826'),
       },
     },
+    latestOppfolgingstilfelle: {
+      oppfolgingstilfelleStart: new Date('2022-10-25'),
+      oppfolgingstilfelleEnd: new Date('2022-12-31'),
+      varighetUker: 2,
+      virksomhetList: [
+        {
+          virksomhetsnummer: '987654321',
+          virksomhetsnavn: 'NAV Security',
+        },
+        {
+          virksomhetsnummer: '987654320',
+          virksomhetsnavn: 'Annen Virksomhet AS',
+        },
+      ],
+    },
   },
   {
     ...behandletPerson,
@@ -65,6 +80,17 @@ export const personoversiktEnhetMock: PersonOversiktStatusDTO[] = [
     motestatus: undefined,
     behandlerdialogUbehandlet: true,
     oppfolgingsoppgave: null,
+    latestOppfolgingstilfelle: {
+      oppfolgingstilfelleStart: new Date('2022-10-25'),
+      oppfolgingstilfelleEnd: new Date('2022-12-31'),
+      varighetUker: 2,
+      virksomhetList: [
+        {
+          virksomhetsnummer: '987654328',
+          virksomhetsnavn: 'Bolle Og Brus',
+        },
+      ],
+    },
   },
   {
     ...behandletPerson,

--- a/src/sider/oversikt/sokeresultat/oversikttable/PersonRadVirksomhetColumn.tsx
+++ b/src/sider/oversikt/sokeresultat/oversikttable/PersonRadVirksomhetColumn.tsx
@@ -32,6 +32,7 @@ export const PersonRadVirksomhetColumn = ({
         open={showVirksomheter}
         onClose={() => setShowVirksomheter(false)}
         anchorEl={virksomehtRef.current}
+        placement="top-start"
       >
         <Popover.Content>{companyNames.join(', ')}</Popover.Content>
       </Popover>

--- a/src/sider/sokperson/SokPersonResultat.tsx
+++ b/src/sider/sokperson/SokPersonResultat.tsx
@@ -5,6 +5,7 @@ import { BodyShort, Box, Table } from '@navikt/ds-react';
 import { LinkSyfomodiaperson } from '@/components/LinkSyfomodiaperson';
 import { toLastnameFirstnameFormat } from '@/utils/stringUtil';
 import { toPersonData } from '@/utils/toPersondata';
+import { PersonRadVirksomhetColumn } from '@/sider/oversikt/sokeresultat/oversikttable/PersonRadVirksomhetColumn';
 
 const texts = {
   noResults: {
@@ -23,7 +24,10 @@ export default function SokPersonResultat({
 }: Props): ReactElement {
   const { columns: allColumns } = useSorting();
   const columns = allColumns.filter(
-    (column) => column.sortKey === 'NAME' || column.sortKey === 'FNR'
+    (column) =>
+      column.sortKey === 'NAME' ||
+      column.sortKey === 'FNR' ||
+      column.sortKey === 'COMPANY'
   );
 
   const personer = Object.entries(toPersonData(sokeresultater, []));
@@ -66,6 +70,9 @@ export default function SokPersonResultat({
                   linkText={fnr}
                 />
               )}
+            </Table.DataCell>
+            <Table.DataCell textSize="small">
+              <PersonRadVirksomhetColumn personData={persondata} />
             </Table.DataCell>
           </Table.Row>
         ))}

--- a/test/components/SokPersonTest.tsx
+++ b/test/components/SokPersonTest.tsx
@@ -11,6 +11,7 @@ import { SokDTO } from '@/api/types/sokDTO';
 import { parseDateString } from '@/utils/dateUtils';
 import { mockServer } from '../setup';
 import { mockSokPerson } from '@/mocks/personoversikt/mockPersonoversikt';
+import { mockEreg } from '@/mocks/ereg/mockEreg';
 
 let queryClient: QueryClient;
 
@@ -29,6 +30,7 @@ describe('SokPerson', () => {
   beforeEach(() => {
     queryClient = testQueryClient();
     mockServer.use(mockSokPerson());
+    mockServer.use(mockEreg);
   });
 
   it('should render SokPerson with fields', () => {
@@ -135,11 +137,17 @@ describe('SokPerson', () => {
 
     await userEvent.click(screen.getByRole('button', { name: 'Søk' }));
 
-    expect(await screen.findByText('Navn')).to.exist;
-    expect(await screen.findByText('Fødselsnummer')).to.exist;
-    expect(await screen.findByText('Heis, Korrupt')).to.exist;
-    expect(await screen.findByText('Bordsen, Korrupt')).to.exist;
-    expect(await screen.findByText('01999911111')).to.exist;
-    expect(await screen.findByText('99999922222')).to.exist;
+    expect(await screen.findByRole('columnheader', { name: 'Navn' })).to.exist;
+    expect(await screen.findByRole('columnheader', { name: 'Fødselsnummer' }))
+      .to.exist;
+    expect(await screen.findByRole('columnheader', { name: 'Virksomhet' })).to
+      .exist;
+    expect(await screen.findByRole('link', { name: 'Heis, Korrupt' })).to.exist;
+    expect(await screen.findByRole('link', { name: 'Bordsen, Korrupt' })).to
+      .exist;
+    expect(await screen.findByRole('cell', { name: '01999911111' })).to.exist;
+    expect(await screen.findByRole('cell', { name: '99999922222' })).to.exist;
+    expect(await screen.findByRole('cell', { name: 'NAV Security' })).to.exist;
+    expect(await screen.findByRole('cell', { name: 'Bolle Og Brus' })).to.exist;
   });
 });


### PR DESCRIPTION
### Hva har blitt lagt til✨🌈

Gjenbruker virksomhetskolonnen fra min/enhetens oversikt i søkeresultat-tabellen.
Kan merges etter https://github.com/navikt/syfooversiktsrv/pull/520 (henter ut virksomhetsnummer fra oppfølgingstilfellet til personene i søkeresultatet)

### Screenshots 📸✨

![image](https://github.com/user-attachments/assets/28bb3b10-9039-4052-b752-0fd14a7f3aa3)
