### PR TITLE
IS-3179: Lagt til informasjon om forhåndsvarsler som ikke har blitt sendt ut

### DIFF
--- a/src/components/EksternLenke.tsx
+++ b/src/components/EksternLenke.tsx
@@ -1,0 +1,23 @@
+import React, { ReactNode } from 'react';
+import { Link } from '@navikt/ds-react';
+import { ExternalLinkIcon } from '@navikt/aksel-icons';
+
+interface Props {
+  href: string;
+  children: ReactNode;
+  className?: string;
+}
+
+export function EksternLenke({ href, children, className }: Props) {
+  return (
+    <Link
+      href={href}
+      className={className}
+      target="_blank"
+      rel="noopener noreferrer"
+    >
+      {children}
+      <ExternalLinkIcon title="Ekstern lenke" fontSize="1.25rem" />
+    </Link>
+  );
+}

--- a/src/components/Systemvarsel.tsx
+++ b/src/components/Systemvarsel.tsx
@@ -9,7 +9,12 @@ const texts = {
 //TODO: Kan fjernes etter at ny frist har utgått: 09.04.25
 export default function Systemvarsel() {
   return (
-    <Alert variant={'error'} size={'medium'} className={'mb-4'}>
+    <Alert
+      variant={'error'}
+      size={'medium'}
+      className={'mb-4'}
+      contentMaxWidth={false}
+    >
       <BodyShort>{texts.forhandsvarselSystemfeil}</BodyShort>
     </Alert>
   );

--- a/src/components/Systemvarsel.tsx
+++ b/src/components/Systemvarsel.tsx
@@ -1,11 +1,10 @@
-import { Alert, BodyShort, Label, Link } from '@navikt/ds-react';
-import React, { ReactNode } from 'react';
-import { ExternalLinkIcon } from '@navikt/aksel-icons';
+import { Alert, BodyShort, Label } from '@navikt/ds-react';
+import React from 'react';
 
 const texts = {
-  header: 'Teknisk feil påvirket forhåndsvarsler mellom 27.februar - 12. mars',
+  header: 'Teknisk feil påvirket forhåndsvarsler mellom 27. februar - 12. mars',
   info:
-    'Grunnet teknisk feil har ikke forhåndsvarsel i perioden 27. februar – 12. mars blitt varslet på riktig måte. I mange av sakene har bruker fått forlenget frist, og fristen i Modia er oppdatert. Dersom berørte brukere tar kontakt, skal det gis forlenget frist.',
+    'Grunnet teknisk feil har ikke forhåndsvarsel i perioden 27. februar – 12. mars blitt varslet på riktig måte. I mange av sakene har bruker fått forlenget frist til 9. april 2025, og fristen i Modia er oppdatert tilsvarende. Dersom berørte brukere tar kontakt, skal det gis forlenget frist.',
   linkText: 'Du kan lese mer om dette på Navet',
   url: '',
 };
@@ -20,21 +19,6 @@ export default function Systemvarsel() {
     >
       <Label>{texts.header}</Label>
       <BodyShort>{texts.info}</BodyShort>
-      <EksternLenke href={texts.url}>{texts.linkText}</EksternLenke>
     </Alert>
-  );
-}
-
-interface EksternLenkeProps {
-  href: string;
-  children: ReactNode;
-}
-
-export function EksternLenke({ href, children }: EksternLenkeProps) {
-  return (
-    <Link href={href} target="_blank" rel="noopener noreferrer">
-      {children}
-      <ExternalLinkIcon title="Ekstern lenke" fontSize="1.25rem" />
-    </Link>
   );
 }

--- a/src/components/Systemvarsel.tsx
+++ b/src/components/Systemvarsel.tsx
@@ -1,12 +1,15 @@
-import { Alert, BodyShort } from '@navikt/ds-react';
-import React from 'react';
+import { Alert, BodyShort, Label, Link } from '@navikt/ds-react';
+import React, { ReactNode } from 'react';
+import { ExternalLinkIcon } from '@navikt/aksel-icons';
 
 const texts = {
-  forhandsvarselSystemfeil:
+  header: 'Teknisk feil påvirket forhåndsvarsler mellom 27.februar - 12. mars',
+  info:
     'Grunnet teknisk feil har ikke forhåndsvarsel i perioden 27. februar – 12. mars blitt varslet på riktig måte. I mange av sakene har bruker fått forlenget frist, og fristen i Modia er oppdatert. Dersom berørte brukere tar kontakt, skal det gis forlenget frist.',
+  linkText: 'Du kan lese mer om dette på Navet',
+  url: '',
 };
 
-//TODO: Kan fjernes etter at ny frist har utgått: 09.04.25
 export default function Systemvarsel() {
   return (
     <Alert
@@ -15,7 +18,23 @@ export default function Systemvarsel() {
       className={'mb-4'}
       contentMaxWidth={false}
     >
-      <BodyShort>{texts.forhandsvarselSystemfeil}</BodyShort>
+      <Label>{texts.header}</Label>
+      <BodyShort>{texts.info}</BodyShort>
+      <EksternLenke href={texts.url}>{texts.linkText}</EksternLenke>
     </Alert>
+  );
+}
+
+interface EksternLenkeProps {
+  href: string;
+  children: ReactNode;
+}
+
+export function EksternLenke({ href, children }: EksternLenkeProps) {
+  return (
+    <Link href={href} target="_blank" rel="noopener noreferrer">
+      {children}
+      <ExternalLinkIcon title="Ekstern lenke" fontSize="1.25rem" />
+    </Link>
   );
 }

--- a/src/components/Systemvarsel.tsx
+++ b/src/components/Systemvarsel.tsx
@@ -1,0 +1,16 @@
+import { Alert, BodyShort } from '@navikt/ds-react';
+import React from 'react';
+
+const texts = {
+  forhandsvarselSystemfeil:
+    'Grunnet teknisk feil har ikke forhåndsvarsel i perioden 27. februar – 12. mars blitt varslet på riktig måte. I mange av sakene har bruker fått forlenget frist, og fristen i Modia er oppdatert. Dersom berørte brukere tar kontakt, skal det gis forlenget frist.',
+};
+
+//TODO: Kan fjernes etter at ny frist har utgått: 09.04.25
+export default function Systemvarsel() {
+  return (
+    <Alert variant={'error'} size={'medium'} className={'mb-4'}>
+      <BodyShort>{texts.forhandsvarselSystemfeil}</BodyShort>
+    </Alert>
+  );
+}

--- a/src/sider/oversikt/OversiktContainer.tsx
+++ b/src/sider/oversikt/OversiktContainer.tsx
@@ -13,6 +13,7 @@ import { getWeeksBetween } from '@/utils/dateUtils';
 import { useFeatureToggles } from '@/data/unleash/unleashQueryHooks';
 import { TabType, useTabType } from '@/hooks/useTabType';
 import Oversikt from '@/sider/oversikt/Oversikt';
+import Systemvarsel from '@/components/Systemvarsel';
 
 function logPageView(tab: TabType) {
   Amplitude.logEvent({
@@ -67,6 +68,7 @@ export default function OversiktContainer(): ReactElement {
       <div className="flex flex-col mx-8">
         <NotificationBar />
         <NavigationBar />
+        <Systemvarsel />
         <ContainerContent />
         {showFlexjar && personoversiktQuery.isSuccess && (
           <Flexjar side={toReadableString(selectedTab)} />


### PR DESCRIPTION
### Hva har blitt lagt til✨🌈
Lagt til boks med informasjon om at forhåndsvarsler ikke har gått ut til bruker (gjelder både `Min oversikt` og `Enhetens oversikt`)

Må vente på følgende før merge:
- [x] Oppretting av nye varsler
- [ ] Legge inn lenke til informasjon (Gjøres i egen PR)

### Screenshots 📸✨
![image](https://github.com/user-attachments/assets/3b1a656f-5b40-4318-bb49-dc0678b60836)
