### PR TITLE
IS-3239: Add amplitude logging of tildeling av oppfolgingsenhet

### DIFF
--- a/src/utils/amplitude.ts
+++ b/src/utils/amplitude.ts
@@ -12,6 +12,7 @@ export enum EventType {
   ButtonClick = 'knapp trykket',
   SortingColumn = 'kolonne sortert på',
   AmountDisplayed = 'antall vist',
+  AmountChanged = 'antall endret',
   ErrorMessageShowed = 'feilmelding vist',
 }
 
@@ -67,6 +68,15 @@ type EventAmountDisplayed = {
   };
 };
 
+type EventAmountChanged = {
+  type: EventType.AmountChanged;
+  data: {
+    url: string;
+    antall: number;
+    handling: string;
+  };
+};
+
 type ErrorMessageShowed = {
   type: EventType.ErrorMessageShowed;
   data: {
@@ -83,7 +93,8 @@ type Event =
   | EventButtonClick
   | EventSortingColumn
   | EventAmountDisplayed
-  | ErrorMessageShowed;
+  | ErrorMessageShowed
+  | EventAmountChanged;
 
 export const logEvent = (event: Event) =>
   amplitude.track(event.type, { ...event.data });


### PR DESCRIPTION
### Hva har blitt lagt til✨🌈

Er ikke nødvendigvis sikker på om det blir helt rett logikk, men jeg har i alle fall tenkt:
- Vi vil måle hvor mange de klarte å flytte av gangen, feks 2 stk. Selve hendelsen teller antall ganger de bruker funksjonaliteten, og `antall` forteller hvor mange de flyttet av gangen. Mulig det er bedre å sende med `maybeAntall` her hvis vi heller vil måle hvor mange de prøvde å flytte, ikke bare hvor mange som var suksessfulle
- Vi vil måle hvor ofte de får en feil fra backenden
- Vi vil måle dersom de har fått til noen, men ikke alle. Dette utfallet fører til to måleinnslag i amplitude nå. Jeg tenker vi vil se på prosentvis hvor mange som feiler helt, feiler litt og ikke feiler, men da burde vi kanskje ikke dobbelt-telle de som feiler litt 🤔
