### PR TITLE
IS-3252: Move feedback-alerts to sticky part of toolbar

### DIFF
--- a/src/sider/oversikt/sokeresultat/Sokeresultat.tsx
+++ b/src/sider/oversikt/sokeresultat/Sokeresultat.tsx
@@ -13,7 +13,6 @@ import { useFilters } from '@/context/filters/FilterContext';
 import { OversiktTableContainer } from '@/sider/oversikt/sokeresultat/oversikttable/OversiktTableContainer';
 import { TabType, useTabType } from '@/hooks/useTabType';
 import { filterUfordelteBrukere } from '@/sider/oversikt/filter/UfordelteBrukereFilter';
-import { Alert } from '@navikt/ds-react';
 import Toolbar from '@/sider/oversikt/sokeresultat/toolbar/Toolbar';
 
 interface Props {
@@ -27,7 +26,6 @@ export default function Sokeresultat({ allEvents }: Props) {
   const [selectedPersoner, setSelectedPersoner] = useState<string[]>([]);
   const [startItem, setStartItem] = useState(0);
   const [endItem, setEndItem] = useState(0);
-  const [tableActionError, setTableActionError] = useState('');
 
   useEffect(() => {
     setSelectedPersoner([]);
@@ -69,13 +67,8 @@ export default function Sokeresultat({ allEvents }: Props) {
         checkAllHandler={checkAllHandler}
         selectedPersoner={selectedPersoner}
         setSelectedPersoner={setSelectedPersoner}
-        setTableActionError={setTableActionError}
       />
-      {!!tableActionError && (
-        <Alert variant="error" size="small" className="mb-2 mt-2">
-          {tableActionError}
-        </Alert>
-      )}
+
       <OversiktTableContainer
         personregister={filteredEvents.value}
         startItem={startItem}

--- a/src/sider/oversikt/sokeresultat/toolbar/TildelOppfolgingsenhet/TildelOppfolgingsenhetButton.tsx
+++ b/src/sider/oversikt/sokeresultat/toolbar/TildelOppfolgingsenhet/TildelOppfolgingsenhetButton.tsx
@@ -1,5 +1,6 @@
 import React, { useEffect } from 'react';
 import { Button } from '@navikt/ds-react';
+import { FeedbackNotification } from '@/sider/oversikt/sokeresultat/toolbar/Toolbar';
 
 const text = {
   buttonLabelTildelOppfolgingsenhet: 'Tildel oppfølgingenhet',
@@ -10,26 +11,29 @@ const text = {
 interface Props {
   modalRef: React.RefObject<HTMLDialogElement | null>;
   selectedPersoner: string[];
-  setTableActionError: (error: string) => void;
+  setTableFeedbackNotification: (
+    feedbackNotification: FeedbackNotification | undefined
+  ) => void;
 }
 
 export default function TildelOppfolgingsenhetButton({
   modalRef,
   selectedPersoner,
-  setTableActionError,
+  setTableFeedbackNotification,
 }: Props) {
-  const [isClicked, setIsClicked] = React.useState(false);
   useEffect(() => {
-    if (isClicked && selectedPersoner.length > 0) {
-      setTableActionError('');
+    if (selectedPersoner.length > 0) {
+      setTableFeedbackNotification(undefined);
     }
-  }, [isClicked, selectedPersoner, setTableActionError]);
+  }, [selectedPersoner, setTableFeedbackNotification]);
 
   function onClick() {
-    setIsClicked(true);
     const isNoPersonsSelected = selectedPersoner.length === 0;
     if (isNoPersonsSelected) {
-      setTableActionError(text.noPeopleSelectedErrorMessage);
+      setTableFeedbackNotification({
+        type: 'error',
+        text: text.noPeopleSelectedErrorMessage,
+      });
     } else {
       modalRef.current?.showModal();
     }

--- a/src/sider/oversikt/sokeresultat/toolbar/Toolbar.tsx
+++ b/src/sider/oversikt/sokeresultat/toolbar/Toolbar.tsx
@@ -11,6 +11,7 @@ import TildelOppfolgingsenhetModal from '@/sider/oversikt/sokeresultat/toolbar/T
 import TildelOppfolgingsenhetButton from '@/sider/oversikt/sokeresultat/toolbar/TildelOppfolgingsenhet/TildelOppfolgingsenhetButton';
 import { useFeatureToggles } from '@/data/unleash/unleashQueryHooks';
 import PaginationLabel from '@/sider/oversikt/sokeresultat/toolbar/TildelOppfolgingsenhet/PaginationLabel';
+import { Alert } from '@navikt/ds-react';
 
 const ToolbarStyled = styled.div`
   display: flex;
@@ -24,6 +25,11 @@ const ToolbarStyled = styled.div`
   box-shadow: 0 2px 4px 0 rgba(0, 0, 0, 0.5);
 `;
 
+export interface FeedbackNotification {
+  type: 'success' | 'warning' | 'error';
+  text: string;
+}
+
 export interface Props {
   isAllSelected: boolean;
   numberOfItemsTotal: number;
@@ -31,7 +37,6 @@ export interface Props {
   onPageChange: (startItem: number, endItem: number) => void;
   selectedPersoner: string[];
   setSelectedPersoner: (personer: string[]) => void;
-  setTableActionError: (error: string) => void;
 }
 
 export interface PageInfoType {
@@ -46,6 +51,9 @@ export default function Toolbar(props: Props) {
     firstVisibleIndex: 0,
     lastVisibleIndex: PAGINATED_NUMBER_OF_ITEMS,
   });
+  const [tableFeedbackNotification, setTableFeedbackNotification] = useState<
+    FeedbackNotification | undefined
+  >();
   const modalRef = useRef<HTMLDialogElement>(null);
 
   return (
@@ -67,7 +75,7 @@ export default function Toolbar(props: Props) {
               <TildelOppfolgingsenhetButton
                 modalRef={modalRef}
                 selectedPersoner={props.selectedPersoner}
-                setTableActionError={props.setTableActionError}
+                setTableFeedbackNotification={setTableFeedbackNotification}
               />
             )}
             {toggles.isTildelOppfolgingsenhetEnabled && (
@@ -75,6 +83,7 @@ export default function Toolbar(props: Props) {
                 ref={modalRef}
                 selectedPersoner={props.selectedPersoner}
                 setSelectedPersoner={props.setSelectedPersoner}
+                setTableFeedbackNotification={setTableFeedbackNotification}
               />
             )}
           </div>
@@ -84,6 +93,15 @@ export default function Toolbar(props: Props) {
             setPageInfo={setPageInfo}
           />
         </section>
+        {!!tableFeedbackNotification && (
+          <Alert
+            variant={tableFeedbackNotification.type}
+            size="small"
+            className="m-1"
+          >
+            {tableFeedbackNotification.text}
+          </Alert>
+        )}
       </ToolbarStyled>
     </>
   );

--- a/test/components/TildelOppfolgingsenhetTest.tsx
+++ b/test/components/TildelOppfolgingsenhetTest.tsx
@@ -37,6 +37,7 @@ const renderTildelOppfolgingsenhetModal = () =>
             ref={modalRef}
             selectedPersoner={[selectedFnr]}
             setSelectedPersoner={() => void 0}
+            setTableFeedbackNotification={() => void 0}
           />
         </AktivEnhetContext.Provider>
       </QueryClientProvider>


### PR DESCRIPTION
### Hva har blitt lagt til✨🌈

Fjerner bruk av den globale notification-banneret og flytter feedbacken til den sticky toolbaren. Det gir noen fordeler:
- Alle tilbakemeldinger rundt flyttingen er på samme sted
- Alertene er sticky dersom man scroller nedover lista og brukeren får feedback der man står i lista (må ikke scrolle opp for å se)
- Notificationen blir borte dersom man bytter enhet/side, der den tidligere hang igjen (lite sannsynlig case i prod, men fint å få ryddet opp likevel)

Samtidig så blir ikke Notification brukt noe mer lenger, men den ligger der som en global hook man kan koble seg på når vi trenger det (feks sånn som når vi hadde prodfeil med forhåndsvarslene)

### Screenshots 📸✨

https://github.com/user-attachments/assets/59c20987-9f1c-47ec-bede-b5c622165285


