### PR TITLE
IS: Update Helmet and turn on CSP

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -41,7 +41,7 @@
         "express": "4.21.2",
         "express-http-proxy": "1.6.3",
         "express-session": "1.18.1",
-        "helmet": "4.6.0",
+        "helmet": "8.1.0",
         "https-proxy-agent": "5.0.1",
         "jose": "4.15.5",
         "nav-frontend-chevron": "1.0.28",
@@ -10208,12 +10208,12 @@
       "license": "MIT"
     },
     "node_modules/helmet": {
-      "version": "4.6.0",
-      "resolved": "https://registry.npmjs.org/helmet/-/helmet-4.6.0.tgz",
-      "integrity": "sha512-HVqALKZlR95ROkrnesdhbbZJFi/rIVSoNq6f3jA/9u6MIbTsPh3xZwihjeI5+DO/2sOV6HMHooXcEOuwskHpTg==",
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/helmet/-/helmet-8.1.0.tgz",
+      "integrity": "sha512-jOiHyAZsmnr8LqoPGmCjYAaiuWwjAPLgY8ZX2XrmHawt99/u1y6RgrZMTeoPfpUbV96HOalYgz1qzkRbw54Pmg==",
       "license": "MIT",
       "engines": {
-        "node": ">=10.0.0"
+        "node": ">=18.0.0"
       }
     },
     "node_modules/hoist-non-react-statics": {

--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
     "express": "4.21.2",
     "express-http-proxy": "1.6.3",
     "express-session": "1.18.1",
-    "helmet": "4.6.0",
+    "helmet": "8.1.0",
     "https-proxy-agent": "5.0.1",
     "jose": "4.15.5",
     "nav-frontend-chevron": "1.0.28",

--- a/server.ts
+++ b/server.ts
@@ -6,7 +6,6 @@ import prometheus from 'prom-client';
 import { getOpenIdClient, getOpenIdIssuer } from './server/authUtils';
 import { setupProxy } from './server/proxy';
 import { setupSession } from './server/session';
-
 import unleash = require('./server/unleash');
 
 // Prometheus metrics
@@ -26,8 +25,17 @@ const server = express();
 server.use(express.json() as any);
 server.use(
   helmet({
-    contentSecurityPolicy: false,
-  }) as any
+    contentSecurityPolicy: {
+      useDefaults: true,
+      directives: {
+        'default-src': ["'self'", 'https://*.nav.no'],
+        'script-src': ["'self'", "'unsafe-inline'", 'https://*.nav.no'],
+        'style-src': ["'self'", "'unsafe-inline'", 'https://*.nav.no'],
+        'font-src': ["'self'", 'data:', 'https://*.nav.no'],
+        'connect-src': ["'self'", 'https://*.nav.no'],
+      },
+    },
+  })
 );
 
 const nocache = (


### PR DESCRIPTION
### Hva har blitt lagt til✨🌈

Kommer fra: https://github.com/navikt/syfooversikt/security/code-scanning/6

Denne krever nok litt testing, både fordi det er mange major-versjoner, og fordi vi endrer på reglene her.

Fra Copilot:
> When updating helmet from 4.6.0 to 8.1.0, there are several breaking changes to be aware of:
**Key Breaking Changes**
> - TypeScript types - Helmet 8.x has improved TypeScript support, so you can remove the as any cast
> - Default CSP - Helmet now enables Content Security Policy by default with stricter settings
> - API changes - Some configuration options have been renamed or restructured

Ser ut som at vi originalt droppet dette fordi det ikke funka med amplitude: https://github.com/navikt/syfomodiaperson/pull/499#issue-788763222

Det skal gå an å evt whiteliste de vi tillater og så kan det være stengt for resten. Prøvde å se hvordan andre i Nav løste dette: https://github.com/search?q=org:navikt+helmet(&type=code&p=1
- https://github.com/navikt/k9-los-web/blob/602cf81497c619f1d1e51906822549526c3df28d/server/server.js#L29
- https://github.com/navikt/lydia-radgiver-frontend/blob/231826fef2c5e09ee5eebfd6ab52709432b268ad/server/app.ts#L37
- https://github.com/navikt/tiltaksgjennomforing/blob/e732c8bac7a0d53f8df0372b04178bbfd492a48a/server/src/server.ts#L34

Tipper vi må passe på amplitude, umami, internflatedekoratøren, telemetry/grafana faro og kanskje mer?

- [x] Teste i dev
- [x] Sjekke Grafana Faro 
- [x] Sjekke Amplitude
- [x] Sjekke at vi fortsatt får inn internflatedekoratøren (den svarte på toppen av modia) og klarer å sette context
- [x] Sjekke generelt api-kall