### PR TITLE
IS-3402: Endre ikon på forhåndsvisning av aktivitetskrav i oversikten

### DIFF
--- a/src/sider/oversikt/sokeresultat/oversikttable/fristdatacell/FristDataCell.tsx
+++ b/src/sider/oversikt/sokeresultat/oversikttable/fristdatacell/FristDataCell.tsx
@@ -80,7 +80,7 @@ function fristerInfo(
             selectedTab === TabType.MIN_OVERSIKT ? (
               <Button
                 size="xsmall"
-                icon={<FileTextIcon aria-hidden fontSize="1.5rem" />}
+                icon={<HourglassTopFilledIcon aria-hidden fontSize="1.5rem" />}
                 className="mr-1"
                 onClick={() => {
                   logAktivitetskravvurderingModalOpenEvent();
@@ -88,7 +88,7 @@ function fristerInfo(
                 }}
               />
             ) : (
-              <FileTextIcon aria-hidden fontSize="1.5rem" />
+              <HourglassTopFilledIcon aria-hidden fontSize="1.5rem" />
             ),
           date: currentVurdering?.frist,
           tooltip: `${


### PR DESCRIPTION
### Hva har blitt lagt til✨🌈
Endre tilbake til timeglass ikon i stedet for "ark" ikon på klikkbar aktivitetskrav avvent vurdering i oversikten etter tilbakemeldinger etter [denne PRen](https://github.com/navikt/syfooversikt/pull/646). Tilbakemeldingen gikk på at de bruker ikonene for å skille hva som er aktivitetskrav og hva som er oppfølgingsoppgave. 

### Screenshots 📸✨
Nå:
<img width="1412" height="529" alt="image" src="https://github.com/user-attachments/assets/5c56eb31-e149-42e5-8fbe-06e0aa3ff313" />

Før:
<img width="1416" height="529" alt="image" src="https://github.com/user-attachments/assets/7d2947de-7977-489c-acf9-717a51802d0d" />

