### PR TITLE
IS-3439: Add stored veileder-filter in dropdown even if no entry in list includes the veileder

### DIFF
--- a/src/sider/oversikt/filter/VeilederFilter.tsx
+++ b/src/sider/oversikt/filter/VeilederFilter.tsx
@@ -48,13 +48,30 @@ export default function VeilederFilter(): ReactElement {
     });
   }
 
-  const veiledereSorted = sortVeiledereBySurnameAsc(
-    filterVeiledereWithActiveOppgave(
+  function getVeiledereSorted(): VeilederDTO[] {
+    const selectedVeiledereInFilter = veiledereQuery.data?.filter((veileder) =>
+      filterState.selectedVeilederIdents.includes(veileder.ident)
+    );
+    const veiledereWithActiveOppgave = filterVeiledereWithActiveOppgave(
       veiledereQuery.data || [],
       personoversiktQuery.data
-    ),
-    aktivVeilederQuery.data?.ident || ''
-  );
+    );
+    const allVeiledere = selectedVeiledereInFilter
+      ? [
+          ...new Set([
+            ...selectedVeiledereInFilter,
+            ...veiledereWithActiveOppgave,
+          ]),
+        ]
+      : veiledereWithActiveOppgave;
+
+    return sortVeiledereBySurnameAsc(
+      allVeiledere,
+      aktivVeilederQuery.data?.ident || ''
+    );
+  }
+
+  const veiledereSorted = getVeiledereSorted();
 
   const selectedVeiledereOptions = veiledereSorted
     .filter((veileder) => selectedVeiledere.includes(veileder.ident))


### PR DESCRIPTION
### Hva har blitt lagt til✨🌈
Jeg tror dette kan løse problemet vårt:

**Hvordan det var:**
Dropdownen viser kun veiledere ved kontoret med aktive oppgaver. Dersom man har slått på filteret for en spesifikk veileder, deretter løser oppgaven til den veilederen / setter sykmeldte på den veilederen til ufordelt, vil ikke veilederen dukke opp i dropdownen lenger, og man har ingen mulighet til å de-selecte den fra dropdown-filteret.

**Nå:**
Vi legger alltid til veilederen som finnes i filteret i den dropdown-lista (fjerner duplikater dersom de allerede ligger i lista), slik at det er mulig å de-selecte den, og oversikten vil fungere som normalt igjen. Jeg tenker dette er et greit mønster, da veileder vil komme inn i oversikten igjen med det siste kjente filteret valgt, se at "nå er det ingen personer igjen på veileder X", og deretter fjerne filteret.


### Screenshots 📸✨

https://github.com/user-attachments/assets/d892cd7d-868b-4cf4-aab2-5613f2f509b2

