### PR TITLE
IS-3591: Add date range filter to overview

### DIFF
--- a/src/context/filters/FilterContext.tsx
+++ b/src/context/filters/FilterContext.tsx
@@ -18,11 +18,15 @@ const FilterContext = React.createContext<{
 });
 
 const FilterProvider = ({ children }: FilterProviderProps) => {
-  const storeKey = 'filters-v2';
+  const storeKey = 'filters-v3';
   const storedFilters = sessionStorage.getItem(storeKey);
   const initialState =
     storedFilters === null ? filterInitialState : JSON.parse(storedFilters);
-  const [filterState, dispatch] = React.useReducer(filterReducer, initialState);
+  const parsedFilters = parseFilters(initialState);
+  const [filterState, dispatch] = React.useReducer(
+    filterReducer,
+    parsedFilters
+  );
   useEffect(() => {
     sessionStorage.setItem(storeKey, JSON.stringify(filterState));
   }, [filterState]);
@@ -32,6 +36,22 @@ const FilterProvider = ({ children }: FilterProviderProps) => {
       {children}
     </FilterContext.Provider>
   );
+};
+
+const parseFilters = (initialState: FilterState): FilterState => {
+  const selectedDateTo = initialState.selectedFristFilters.selectedDateRange.to;
+  const selectedDateFrom =
+    initialState.selectedFristFilters.selectedDateRange.from;
+  return {
+    ...initialState,
+    selectedFristFilters: {
+      ...initialState.selectedFristFilters,
+      selectedDateRange: {
+        to: selectedDateTo ? new Date(selectedDateTo) : undefined,
+        from: selectedDateFrom ? new Date(selectedDateFrom) : undefined,
+      },
+    },
+  };
 };
 
 const useFilters = () => {

--- a/src/context/filters/filterContextActions.ts
+++ b/src/context/filters/filterContextActions.ts
@@ -3,6 +3,7 @@ import {
   AgeFilterOption,
   DatoFilterOption,
 } from '@/utils/hendelseFilteringUtils';
+import { DateRange } from '@/sider/oversikt/filter/types.ts';
 
 export enum ActionType {
   SetTekstFilter,
@@ -44,7 +45,10 @@ export interface SetSelectedCompanies {
 
 export interface SetSelectedDatoFilter {
   type: ActionType.SetSelectedDatoFilter;
-  selectedDatoFilters: DatoFilterOption[];
+  selectedDatoFilters: {
+    selectedDatoOptions: DatoFilterOption[];
+    selectedDateRange: DateRange;
+  };
 }
 
 export interface SetSelectedAgeFilter {

--- a/src/context/filters/filterContextState.ts
+++ b/src/context/filters/filterContextState.ts
@@ -2,6 +2,12 @@ import {
   AgeFilterOption,
   DatoFilterOption,
 } from '@/utils/hendelseFilteringUtils';
+import { DateRange } from '@/sider/oversikt/filter/types.ts';
+
+export interface FristFilter {
+  selectedDatoOptions: DatoFilterOption[];
+  selectedDateRange: DateRange;
+}
 
 export interface HendelseTypeFilter {
   arbeidsgiverOnskerMote: boolean;
@@ -26,7 +32,7 @@ export interface FilterState {
   selectedOptions: string[];
   selectedCompanies: string[];
   selectedBirthDates: string[];
-  selectedFristFilters: DatoFilterOption[];
+  selectedFristFilters: FristFilter;
   selectedAgeFilters: AgeFilterOption[];
   selectedHendelseType: HendelseTypeFilter;
   isUfordelteBrukereFilter: boolean;
@@ -38,7 +44,13 @@ export const filterInitialState: FilterState = {
   selectedOptions: [],
   selectedCompanies: [],
   selectedBirthDates: [],
-  selectedFristFilters: [],
+  selectedFristFilters: {
+    selectedDatoOptions: [],
+    selectedDateRange: {
+      from: undefined,
+      to: undefined,
+    },
+  },
   selectedAgeFilters: [],
   selectedHendelseType: {
     arbeidsgiverOnskerMote: false,

--- a/src/sider/oversikt/filter/DatoFilter.tsx
+++ b/src/sider/oversikt/filter/DatoFilter.tsx
@@ -1,8 +1,15 @@
-import { Checkbox, CheckboxGroup } from '@navikt/ds-react';
+import {
+  Box,
+  Checkbox,
+  CheckboxGroup,
+  DatePicker,
+  useRangeDatepicker,
+} from '@navikt/ds-react';
 import { DatoFilterOption } from '@/utils/hendelseFilteringUtils';
 import React from 'react';
 import { ActionType } from '@/context/filters/filterContextActions';
 import { useFilters } from '@/context/filters/FilterContext';
+import { DateRange } from '@/sider/oversikt/filter/types.ts';
 
 const texts = {
   legend: 'Dato',
@@ -10,28 +17,84 @@ const texts = {
     past: 'Før dagens dato',
     today: 'Dagens dato',
     future: 'Fremtidige datoer',
+    custom: 'Egendefinerte datoer',
+  },
+  datePicker: {
+    description: 'Format: dd.mm.åååå',
+    labelFrom: 'Fra',
+    labelTo: 'Til',
   },
 };
 
 export default function DatoFilter() {
   const { filterState, dispatch: dispatchFilterAction } = useFilters();
-  const onDatoFilterChange = (datoFilters: DatoFilterOption[]) => {
+  const selectedDatoOptions =
+    filterState.selectedFristFilters.selectedDatoOptions;
+  const selectedDateTo = filterState.selectedFristFilters.selectedDateRange.to;
+  const selectedDateFrom =
+    filterState.selectedFristFilters.selectedDateRange.from;
+
+  const onDatoFilterOptionChange = (datoFilters: DatoFilterOption[]) => {
     dispatchFilterAction({
       type: ActionType.SetSelectedDatoFilter,
-      selectedDatoFilters: datoFilters,
+      selectedDatoFilters: {
+        selectedDatoOptions: datoFilters,
+        selectedDateRange: filterState.selectedFristFilters.selectedDateRange,
+      },
     });
   };
+
+  const onDatoRangeChange = (dateRange: DateRange | undefined) => {
+    dispatchFilterAction({
+      type: ActionType.SetSelectedDatoFilter,
+      selectedDatoFilters: {
+        selectedDatoOptions: selectedDatoOptions,
+        selectedDateRange: {
+          from: dateRange?.from,
+          to: dateRange?.to,
+        },
+      },
+    });
+  };
+
+  const { datepickerProps, toInputProps, fromInputProps } = useRangeDatepicker({
+    onRangeChange: (dateRange) => onDatoRangeChange(dateRange),
+    allowTwoDigitYear: true,
+    defaultSelected: {
+      to: selectedDateTo,
+      from: selectedDateFrom,
+    },
+  });
 
   return (
     <CheckboxGroup
       legend={texts.legend}
-      onChange={(val: DatoFilterOption[]) => onDatoFilterChange(val)}
-      value={filterState.selectedFristFilters}
+      onChange={(val: DatoFilterOption[]) => onDatoFilterOptionChange(val)}
+      value={selectedDatoOptions}
       size="small"
     >
       <Checkbox value={DatoFilterOption.Past}>{texts.option.past}</Checkbox>
       <Checkbox value={DatoFilterOption.Today}>{texts.option.today}</Checkbox>
       <Checkbox value={DatoFilterOption.Future}>{texts.option.future}</Checkbox>
+      <Checkbox value={DatoFilterOption.Custom}>{texts.option.custom}</Checkbox>
+
+      {selectedDatoOptions?.includes(DatoFilterOption.Custom) && (
+        <Box className={'ml-4 mt-2'}>
+          <DatePicker {...datepickerProps}>
+            <DatePicker.Input
+              {...fromInputProps}
+              label={texts.datePicker.labelFrom}
+              description={texts.datePicker.description}
+              className={'mb-2'}
+            />
+            <DatePicker.Input
+              {...toInputProps}
+              label={texts.datePicker.labelTo}
+              description={texts.datePicker.description}
+            />
+          </DatePicker>
+        </Box>
+      )}
     </CheckboxGroup>
   );
 }

--- a/src/sider/oversikt/filter/types.ts
+++ b/src/sider/oversikt/filter/types.ts
@@ -1,0 +1,4 @@
+export type DateRange = {
+  from: Date | undefined;
+  to?: Date | undefined;
+};

--- a/src/utils/dateUtils.ts
+++ b/src/utils/dateUtils.ts
@@ -1,5 +1,6 @@
 import dayjs from 'dayjs';
 import minMax from 'dayjs/plugin/minMax';
+import { DateRange } from '@/sider/oversikt/filter/types.ts';
 
 dayjs.extend(minMax);
 
@@ -11,31 +12,28 @@ export function toReadableDate(dateArg: Date | null): string {
 }
 
 export function isPast(compareDate: Date): boolean {
-  const currentDate = new Date();
-  const date = new Date(compareDate);
-  const isNotToday = !(
-    date.getFullYear() === currentDate.getFullYear() &&
-    date.getMonth() === currentDate.getMonth() &&
-    date.getDate() === currentDate.getDate()
-  );
-  const isInThePast = date < currentDate;
-  return isNotToday && isInThePast;
+  return dayjs(compareDate).isBefore(dayjs(), 'day');
 }
 
 export function isToday(compareDate: Date): boolean {
-  const currentDate = new Date();
-  const date = new Date(compareDate);
-  return (
-    date.getFullYear() === currentDate.getFullYear() &&
-    date.getMonth() === currentDate.getMonth() &&
-    date.getDate() === currentDate.getDate()
-  );
+  return dayjs(compareDate).isSame(dayjs(), 'day');
 }
 
 export function isFuture(compareDate: Date): boolean {
-  const currentDate = new Date();
-  const date = new Date(compareDate);
-  return currentDate < date;
+  return dayjs(compareDate).isAfter(dayjs(), 'day');
+}
+
+export function isWithinRange(
+  compareDate: Date,
+  dateRange: DateRange
+): boolean {
+  if (!dateRange?.from || !dateRange?.to) return true;
+
+  const date = dayjs(compareDate);
+  return (
+    !date.isBefore(dayjs(dateRange.from), 'day') &&
+    !date.isAfter(dayjs(dateRange.to), 'day')
+  );
 }
 
 export function earliestDate(dateArray: Date[]): Date | null {

--- a/src/utils/hendelseFilteringUtils.tsx
+++ b/src/utils/hendelseFilteringUtils.tsx
@@ -4,12 +4,16 @@ import {
 } from '@/api/types/personregisterTypes';
 import { firstCompanyNameFromPersonData } from './personDataUtil';
 import { VeilederDTO } from '@/api/types/veiledereTypes';
-import { HendelseTypeFilter } from '@/context/filters/filterContextState';
+import {
+  FristFilter,
+  HendelseTypeFilter,
+} from '@/context/filters/filterContextState';
 import {
   earliestDate,
   isFuture,
   isPast,
   isToday,
+  isWithinRange,
   latestDate,
 } from '@/utils/dateUtils';
 import { SortDirection, Sorting } from '@/hooks/useSorting';
@@ -90,13 +94,14 @@ export enum DatoFilterOption {
   Past = 'Past',
   Today = 'Today',
   Future = 'Future',
+  Custom = 'Custom',
 }
 
 export function filterOnDato(
   personregister: PersonregisterState,
-  selectedDatoFilters: DatoFilterOption[]
+  selectedDatoFilters: FristFilter
 ): PersonregisterState {
-  const isNoFilter = selectedDatoFilters.length === 0;
+  const isNoFilter = selectedDatoFilters.selectedDatoOptions.length === 0;
   if (isNoFilter) {
     return personregister;
   }
@@ -111,9 +116,7 @@ export function filterOnDato(
       persondata.dialogmoteAvvent?.frist,
     ];
 
-    if (datoer.every((dato) => dato === null)) {
-      return true;
-    }
+    if (datoer.every((dato) => dato === null)) return true;
 
     return datoer.some(
       (dato) => dato && isInDatoFilter(selectedDatoFilters, dato)
@@ -123,11 +126,8 @@ export function filterOnDato(
   return Object.fromEntries(filtered);
 }
 
-function isInDatoFilter(
-  selectedFilters: DatoFilterOption[],
-  dato: Date
-): boolean {
-  return selectedFilters.some((datoFilter) => {
+function isInDatoFilter(selectedFilters: FristFilter, dato: Date): boolean {
+  return selectedFilters.selectedDatoOptions.some((datoFilter) => {
     switch (datoFilter) {
       case DatoFilterOption.Past:
         return isPast(dato);
@@ -135,6 +135,8 @@ function isInDatoFilter(
         return isToday(dato);
       case DatoFilterOption.Future:
         return isFuture(dato);
+      case DatoFilterOption.Custom:
+        return isWithinRange(dato, selectedFilters.selectedDateRange);
     }
   });
 }

--- a/test/components/Sokeresultat.test.tsx
+++ b/test/components/Sokeresultat.test.tsx
@@ -57,7 +57,13 @@ describe('Sokeresultat', () => {
       selectedOptions: [],
       selectedCompanies: [],
       selectedBirthDates: [],
-      selectedFristFilters: [],
+      selectedFristFilters: {
+        selectedDatoOptions: [],
+        selectedDateRange: {
+          to: undefined,
+          from: undefined,
+        },
+      },
       selectedAgeFilters: [],
       selectedHendelseType: {
         arbeidsgiverOnskerMote: false,

--- a/test/utils/dateUtils.test.ts
+++ b/test/utils/dateUtils.test.ts
@@ -1,5 +1,11 @@
-import { describe, expect, it } from 'vitest';
-import { toReadableDate } from '@/utils/dateUtils';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import {
+  isFuture,
+  isPast,
+  isToday,
+  isWithinRange,
+  toReadableDate,
+} from '@/utils/dateUtils';
 
 describe('dateUtils', () => {
   describe('readable date', () => {
@@ -16,6 +22,36 @@ describe('dateUtils', () => {
       const date = new Date('2020-12-01T10:12:05.913826');
       const readableDate = toReadableDate(date);
       expect(readableDate).to.equal('01.12.2020');
+    });
+  });
+
+  describe('calendar day comparisons', () => {
+    beforeEach(() => {
+      vi.useFakeTimers();
+      vi.setSystemTime(new Date('2026-04-28T12:00:00.000Z'));
+    });
+
+    afterEach(() => {
+      vi.useRealTimers();
+    });
+
+    it('treats timestamps on the same calendar day as today', () => {
+      const compareDate = new Date('2026-04-28T00:00:00.000Z');
+
+      expect(isToday(compareDate)).to.equal(true);
+      expect(isPast(compareDate)).to.equal(false);
+      expect(isFuture(compareDate)).to.equal(false);
+    });
+
+    it('treats timestamps on the same calendar day as within an inclusive range', () => {
+      const compareDate = new Date('2026-04-28T00:00:00.000Z');
+
+      const isDateWithinRange = isWithinRange(compareDate, {
+        from: new Date('2026-04-28T18:00:00.000Z'),
+        to: new Date('2026-04-28T18:00:00.000Z'),
+      });
+
+      expect(isDateWithinRange).to.equal(true);
     });
   });
 });

--- a/test/utils/hendelseFilteringUtilsTest.ts
+++ b/test/utils/hendelseFilteringUtilsTest.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import {
   DatoFilterOption,
   filterHendelser,
@@ -15,6 +15,7 @@ import { HendelseTypeFilter } from '@/context/filters/filterContextState';
 import { addWeeks, subWeeks } from '@/utils/dateUtils';
 import { getOppfolgingsoppgave } from '@/mocks/data/personoversiktEnhetMock';
 import { AktivitetskravStatus } from '@/api/types/personoversiktTypes';
+import dayjs from 'dayjs';
 
 export function createPersonDataWithName(
   name: string,
@@ -764,9 +765,13 @@ describe('hendelseFilteringUtils', () => {
       };
 
       it('Only returns elements with frist dato before today', () => {
-        const filteredPersonregister = filterOnDato(personregister, [
-          DatoFilterOption.Past,
-        ]);
+        const filteredPersonregister = filterOnDato(personregister, {
+          selectedDatoOptions: [DatoFilterOption.Past],
+          selectedDateRange: {
+            to: undefined,
+            from: undefined,
+          },
+        });
 
         expect(Object.keys(filteredPersonregister).length).to.equal(2);
         expect(Object.keys(filteredPersonregister)[0]).to.equal('16614407794');
@@ -774,9 +779,13 @@ describe('hendelseFilteringUtils', () => {
       });
 
       it('Only returns elements with frist dato today', () => {
-        const filteredPersonregister = filterOnDato(personregister, [
-          DatoFilterOption.Today,
-        ]);
+        const filteredPersonregister = filterOnDato(personregister, {
+          selectedDatoOptions: [DatoFilterOption.Today],
+          selectedDateRange: {
+            to: undefined,
+            from: undefined,
+          },
+        });
 
         expect(Object.keys(filteredPersonregister).length).to.equal(2);
         expect(Object.keys(filteredPersonregister)[0]).to.equal('16614407796');
@@ -784,14 +793,83 @@ describe('hendelseFilteringUtils', () => {
       });
 
       it('Only returns elements with frist dato in the future', () => {
-        const filteredPersonregister = filterOnDato(personregister, [
-          DatoFilterOption.Future,
-        ]);
+        const filteredPersonregister = filterOnDato(personregister, {
+          selectedDatoOptions: [DatoFilterOption.Future],
+          selectedDateRange: {
+            to: undefined,
+            from: undefined,
+          },
+        });
 
         expect(Object.keys(filteredPersonregister).length).to.equal(3);
         expect(Object.keys(filteredPersonregister)[0]).to.equal('16614407798');
         expect(Object.keys(filteredPersonregister)[1]).to.equal('16614407799');
         expect(Object.keys(filteredPersonregister)[2]).to.equal('16614407889');
+      });
+
+      it('Only returns elements with frist dato between range', () => {
+        const filteredPersonregister = filterOnDato(personregister, {
+          selectedDatoOptions: [DatoFilterOption.Custom],
+          selectedDateRange: {
+            from: dayjs().subtract(6, 'day').startOf('day').toDate(),
+            to: dayjs().add(6, 'day').startOf('day').toDate(),
+          },
+        });
+
+        expect(Object.keys(filteredPersonregister).length).to.equal(2);
+        expect(Object.keys(filteredPersonregister)[0]).to.equal('16614407796');
+        expect(Object.keys(filteredPersonregister)[1]).to.equal('16614407797');
+      });
+
+      it('Only returns elements with frist dato on single calendar date in range', () => {
+        const filteredPersonregister = filterOnDato(personregister, {
+          selectedDatoOptions: [DatoFilterOption.Custom],
+          selectedDateRange: {
+            from: new Date(),
+            to: new Date(),
+          },
+        });
+
+        expect(Object.keys(filteredPersonregister).length).to.equal(2);
+        expect(Object.keys(filteredPersonregister)[0]).to.equal('16614407796');
+        expect(Object.keys(filteredPersonregister)[1]).to.equal('16614407797');
+      });
+
+      describe('same calendar day with different times', () => {
+        beforeEach(() => {
+          vi.useFakeTimers();
+          vi.setSystemTime(new Date('2026-04-28T12:00:00.000Z'));
+        });
+
+        afterEach(() => {
+          vi.useRealTimers();
+        });
+
+        it('includes frist on the same day when custom range is a single calendar day', () => {
+          const personregisterWithSameDayFrist: PersonregisterState = {
+            '16614407794': {
+              ...createPersonDataWithName('Box Culder'),
+              oppfolgingsoppgave: getOppfolgingsoppgave(
+                new Date('2026-04-28T00:00:00.000Z')
+              ),
+            },
+          };
+
+          const filteredPersonregister = filterOnDato(
+            personregisterWithSameDayFrist,
+            {
+              selectedDatoOptions: [DatoFilterOption.Custom],
+              selectedDateRange: {
+                from: new Date('2026-04-28T18:00:00.000Z'),
+                to: new Date('2026-04-28T18:00:00.000Z'),
+              },
+            }
+          );
+
+          expect(Object.keys(filteredPersonregister)).to.deep.equal([
+            '16614407794',
+          ]);
+        });
       });
     });
   });


### PR DESCRIPTION
### Hva har blitt lagt til✨🌈

Vi har lagt til egendefinert datoperiode blant filtervalgene. Datoene baserer seg på de samme datoene man har på de andre filtrene, altså "Før dagens dato" osv., bare at her sjekker man mellom periodene. Vi har gjort vårt beste med styling, men her tar vi gjerne imot tilbakemelding :art: Legger ved bilder under.

Det er en fordel å oppgradere Aksel, fordi DatePicker virker noe mer brukervennlig i de nyere versjonene

### Screenshots 📸✨

<img width="279" height="167" alt="image" src="https://github.com/user-attachments/assets/04db74d0-702c-46ab-bf47-42c7ff4b89e4" />
<br>
<img width="410" height="724" alt="image" src="https://github.com/user-attachments/assets/cec7007a-7860-4bb2-be78-91f14c46e418" />
<br>
<img width="268" height="358" alt="image" src="https://github.com/user-attachments/assets/a757d6ba-fa47-47ff-a154-975aab5b3b10" />

