### PR TITLE
IS-4033: Add error message for write access

### DIFF
--- a/src/api/axios.ts
+++ b/src/api/axios.ts
@@ -2,6 +2,7 @@ import axios, { AxiosError } from 'axios';
 import {
   accessDeniedError,
   ApiErrorException,
+  conflictError,
   generalError,
   loginRequiredError,
   networkError,
@@ -41,6 +42,12 @@ function handleAxiosError(error: AxiosError) {
       case 403: {
         throw new ApiErrorException(
           accessDeniedError(error),
+          error.response.status
+        );
+      }
+      case 409: {
+        throw new ApiErrorException(
+          conflictError(error),
           error.response.status
         );
       }

--- a/src/api/errors.ts
+++ b/src/api/errors.ts
@@ -3,6 +3,8 @@ export const defaultErrorTexts = {
   generalError: 'Det skjedde en uventet feil. Vennligst prøv igjen senere.',
   networkError: 'Vi har problemer med nettet, prøv igjen senere.',
   loginRequired: 'Handlingen krever at du logger på.',
+  conflictError:
+    'Det skjedde en uventet feil. Det kan hende en annen veileder har oppdatert siden. Last inn siden på nytt og prøv igjen.',
 };
 
 export enum ErrorType {
@@ -10,6 +12,13 @@ export enum ErrorType {
   GENERAL_ERROR = 'GENERAL_ERROR',
   NETWORK_ERROR = 'NETWORK_ERROR',
   LOGIN_REQUIRED = 'LOGIN_REQUIRED',
+  CONFLICT_ERROR = 'CONFLICT_ERROR',
+}
+
+export function resolveErrorMessage(error: unknown) {
+  return error instanceof ApiErrorException
+    ? error.error.defaultErrorMsg
+    : defaultErrorTexts.generalError;
 }
 
 export class ApiErrorException extends Error {
@@ -41,6 +50,14 @@ export const accessDeniedError = (error: Error): ApiError => {
     type: ErrorType.ACCESS_DENIED,
     message: error.message,
     defaultErrorMsg: defaultErrorTexts.accessDenied,
+  };
+};
+
+export const conflictError = (error: Error): ApiError => {
+  return {
+    type: ErrorType.CONFLICT_ERROR,
+    message: error.message,
+    defaultErrorMsg: defaultErrorTexts.conflictError,
   };
 };
 

--- a/src/context/notification/Notifications.ts
+++ b/src/context/notification/Notifications.ts
@@ -6,7 +6,9 @@ export type NotificationType =
   | 'fetchVeiledereFailed'
   | 'fetchAktivVeilederFailed'
   | 'tildelVeilederFailed'
+  | 'tildelVeilederTilgangFailed'
   | 'tildelOppfolgingsenhetFailed'
+  | 'tildelOppfolgingsenhetTilgangFailed'
   | 'tildelOppfolgingsenhetSuccess';
 
 export interface Notification extends Pick<AlertProps, 'variant'> {
@@ -36,6 +38,12 @@ export const TildelVeilederFailed: Notification = {
     'Det skjedde en feil ved tildeling av veileder. Vennligst prøv igjen senere.',
 };
 
+export const TildelVeilederTilgangFailed: Notification = {
+  type: 'tildelVeilederTilgangFailed',
+  variant: 'error',
+  message: 'Du har ikke tilgang til å tildele veileder.',
+};
+
 export const FetchPersonoversiktFailed: Notification = {
   type: 'fetchPersonoversiktFailed',
   variant: 'error',
@@ -48,4 +56,17 @@ export const FetchPersonregisterFailed: Notification = {
   variant: 'error',
   message:
     'Vi klarte ikke laste inn personregister. Enkelte personer vises uten navn eller diskresjonskode.',
+};
+
+export const TildelOppfolgingsenhetFailed: Notification = {
+  type: 'tildelOppfolgingsenhetFailed',
+  variant: 'error',
+  message:
+    'Det skjedde en feil ved tildeling av oppfølgingsenhet. Vennligst prøv igjen senere.',
+};
+
+export const TildelOppfolgingsenhetTilgangFailed: Notification = {
+  type: 'tildelOppfolgingsenhetTilgangFailed',
+  variant: 'error',
+  message: 'Du har ikke tilgang til å tildele oppfølgingsenhet.',
 };

--- a/src/data/personoversiktHooks.ts
+++ b/src/data/personoversiktHooks.ts
@@ -7,8 +7,6 @@ import { get, post } from '@/api/axios';
 import { useAktivEnhet } from '@/context/aktivEnhet/AktivEnhetContext';
 import { useNotifications } from '@/context/notification/NotificationContext';
 import { FetchPersonoversiktFailed } from '@/context/notification/Notifications';
-import { ApiErrorException } from '@/api/errors';
-import { useAsyncError } from '@/data/useAsyncError';
 import { minutesToMillis } from '@/utils/timeUtils';
 import { useMemo } from 'react';
 import { PERSONOVERSIKT_ROOT } from '@/apiConstants';
@@ -36,7 +34,6 @@ export const useGetPersonstatusQuery = () => {
   const { aktivEnhet } = useAktivEnhet();
   const { toggles } = useGetFeatureToggles();
   const { displayNotification, clearNotification } = useNotifications();
-  const throwError = useAsyncError();
 
   const fetchPersonoversikt = () => {
     const personoversiktData = get<PersonOversiktStatusDTO[]>(
@@ -51,12 +48,8 @@ export const useGetPersonstatusQuery = () => {
     enabled: !!aktivEnhet,
     staleTime: minutesToMillis(5),
     meta: {
-      handleError: (error: Error) => {
-        if (error instanceof ApiErrorException && error.code === 403) {
-          throwError(error);
-        } else {
-          displayNotification(FetchPersonoversiktFailed);
-        }
+      handleError: () => {
+        displayNotification(FetchPersonoversiktFailed);
       },
       handleSuccess: () => clearNotification('fetchPersonoversiktFailed'),
     },

--- a/src/data/personregisterHooks.ts
+++ b/src/data/personregisterHooks.ts
@@ -3,10 +3,8 @@ import { useQuery } from '@tanstack/react-query';
 import { post } from '@/api/axios';
 import { PersonSkjermingskode } from '@/api/types/personregisterTypes';
 import { useGetPersonstatusQuery } from '@/data/personoversiktHooks';
-import { ApiErrorException } from '@/api/errors';
 import { FetchPersonregisterFailed } from '@/context/notification/Notifications';
 import { useNotifications } from '@/context/notification/NotificationContext';
-import { useAsyncError } from '@/data/useAsyncError';
 import { useAktivEnhet } from '@/context/aktivEnhet/AktivEnhetContext';
 
 export const personSkjermingskodeQueryKeys = {
@@ -20,7 +18,6 @@ export const useGetPersonSkjermingskodeQuery = () => {
   const { aktivEnhet } = useAktivEnhet();
   const { data } = useGetPersonstatusQuery();
   const { displayNotification, clearNotification } = useNotifications();
-  const throwError = useAsyncError();
 
   const fnrForPersonerListe = data.map((person) => ({ fnr: person.fnr }));
 
@@ -38,12 +35,8 @@ export const useGetPersonSkjermingskodeQuery = () => {
     queryFn: fetchPersonSkjermingskode,
     enabled: !!aktivEnhet && fnrForPersonerListe.length > 0,
     meta: {
-      handleError: (error: Error) => {
-        if (error instanceof ApiErrorException && error.code === 403) {
-          throwError(error);
-        } else {
-          displayNotification(FetchPersonregisterFailed);
-        }
+      handleError: () => {
+        displayNotification(FetchPersonregisterFailed);
       },
       handleSuccess: () => clearNotification('fetchPersonregisterFailed'),
     },

--- a/src/data/veiledereQueryHooks.ts
+++ b/src/data/veiledereQueryHooks.ts
@@ -11,8 +11,8 @@ import {
   FetchAktivVeilederFailed,
   FetchVeiledereFailed,
   TildelVeilederFailed,
+  TildelVeilederTilgangFailed,
 } from '@/context/notification/Notifications';
-import { useAsyncError } from '@/data/useAsyncError';
 import { ApiErrorException } from '@/api/errors';
 
 export const veiledereQueryKeys = {
@@ -27,7 +27,6 @@ export const veiledereQueryKeys = {
 export const useVeiledereQuery = () => {
   const { aktivEnhet } = useAktivEnhet();
   const { displayNotification, clearNotification } = useNotifications();
-  const throwError = useAsyncError();
 
   const fetchVeiledere = () =>
     get<VeilederDTO[]>(`${SYFOVEILEDER_ROOT}/veiledere?enhetNr=${aktivEnhet}`);
@@ -37,12 +36,8 @@ export const useVeiledereQuery = () => {
     queryFn: fetchVeiledere,
     enabled: !!aktivEnhet,
     meta: {
-      handleError: (error: Error) => {
-        if (error instanceof ApiErrorException && error.code === 403) {
-          throwError(error);
-        } else {
-          displayNotification(FetchVeiledereFailed);
-        }
+      handleError: () => {
+        displayNotification(FetchVeiledereFailed);
       },
       handleSuccess: () => clearNotification('fetchVeiledereFailed'),
     },
@@ -51,7 +46,6 @@ export const useVeiledereQuery = () => {
 
 export function useAktivVeilederQuery() {
   const { displayNotification, clearNotification } = useNotifications();
-  const throwError = useAsyncError();
 
   const fetchVeilederInfo = () =>
     get<VeilederDTO>(`${SYFOVEILEDER_ROOT}/veiledere/self`);
@@ -60,12 +54,8 @@ export function useAktivVeilederQuery() {
     queryKey: veiledereQueryKeys.veiledereInfo,
     queryFn: fetchVeilederInfo,
     meta: {
-      handleError: (error: Error) => {
-        if (error instanceof ApiErrorException && error.code === 403) {
-          throwError(error);
-        } else {
-          displayNotification(FetchAktivVeilederFailed);
-        }
+      handleError: () => {
+        displayNotification(FetchAktivVeilederFailed);
       },
       handleSuccess: () => clearNotification('fetchAktivVeilederFailed'),
     },
@@ -76,7 +66,6 @@ export const useTildelVeileder = () => {
   const queryClient = useQueryClient();
   const { aktivEnhet } = useAktivEnhet();
   const { displayNotification, clearNotification } = useNotifications();
-  const throwError = useAsyncError();
 
   const path = `${PERSONTILDELING_ROOT}/registrer`;
 
@@ -87,6 +76,7 @@ export const useTildelVeileder = () => {
     mutationFn: postTildelVeileder,
     onMutate: (liste: VeilederArbeidstaker[]) => {
       clearNotification('tildelVeilederFailed');
+      clearNotification('tildelVeilederTilgangFailed');
 
       const previousPersonoversikt: PersonOversiktStatusDTO[] =
         queryClient.getQueryData(
@@ -112,12 +102,13 @@ export const useTildelVeileder = () => {
 
       return { previousPersonoversikt };
     },
-    onError: (error, newVeileder, context) => {
+    onError: (error, _, context) => {
       if (error instanceof ApiErrorException && error.code === 403) {
-        throwError(error);
+        displayNotification(TildelVeilederTilgangFailed);
       } else {
         displayNotification(TildelVeilederFailed);
       }
+
       queryClient.setQueryData(
         personoversiktQueryKeys.personoversiktEnhet(aktivEnhet),
         context?.previousPersonoversikt || []

--- a/src/sider/oversikt/sokeresultat/toolbar/TildelOppfolgingsenhet/TildelOppfolgingsenhetModal.tsx
+++ b/src/sider/oversikt/sokeresultat/toolbar/TildelOppfolgingsenhet/TildelOppfolgingsenhetModal.tsx
@@ -116,12 +116,6 @@ export default function TildelOppfolgingsenhetModal({
             });
             setSelectedPersoner([]);
           },
-          onError: () => {
-            setTableFeedbackNotification({
-              type: 'error',
-              text: text.errorMessage,
-            });
-          },
           onSettled: closeModal,
         }
       );

--- a/src/sider/oversikt/sokeresultat/toolbar/TildelOppfolgingsenhet/hooks/usePostTildelOppfolgingsenhet.tsx
+++ b/src/sider/oversikt/sokeresultat/toolbar/TildelOppfolgingsenhet/hooks/usePostTildelOppfolgingsenhet.tsx
@@ -4,10 +4,17 @@ import { post } from '@/api/axios';
 import { PersonOversiktStatusDTO } from '@/api/types/personoversiktTypes';
 import { personoversiktQueryKeys } from '@/data/personoversiktHooks';
 import { useAktivEnhet } from '@/context/aktivEnhet/AktivEnhetContext';
+import { useNotifications } from '@/context/notification/NotificationContext.tsx';
+import { ApiErrorException } from '@/api/errors.ts';
+import {
+  TildelOppfolgingsenhetFailed,
+  TildelOppfolgingsenhetTilgangFailed,
+} from '@/context/notification/Notifications.ts';
 
 export function usePostTildelOppfolgingsenhet() {
   const queryClient = useQueryClient();
   const { aktivEnhet } = useAktivEnhet();
+  const { displayNotification, clearNotification } = useNotifications();
 
   const path = `${SYFOBEHANDLENDEENHET_ROOT}/oppfolgingsenhet-tildelinger`;
   const postTildelOppfolgingsenhet = (
@@ -16,6 +23,10 @@ export function usePostTildelOppfolgingsenhet() {
 
   return useMutation({
     mutationFn: postTildelOppfolgingsenhet,
+    onMutate: () => {
+      clearNotification('tildelOppfolgingsenhetFailed');
+      clearNotification('tildelOppfolgingsenhetTilgangFailed');
+    },
     onSuccess: (data: OppfolgingsenhetTildelingerResponseDTO) => {
       const personer: PersonOversiktStatusDTO[] =
         queryClient.getQueryData(
@@ -35,6 +46,13 @@ export function usePostTildelOppfolgingsenhet() {
         personoversiktQueryKeys.personoversiktEnhet(aktivEnhet),
         updatedPersoner
       );
+    },
+    onError: (error: Error) => {
+      if (error instanceof ApiErrorException && error.code === 403) {
+        displayNotification(TildelOppfolgingsenhetTilgangFailed);
+      } else {
+        displayNotification(TildelOppfolgingsenhetFailed);
+      }
     },
   });
 }

--- a/src/sider/sokperson/SokPerson.tsx
+++ b/src/sider/sokperson/SokPerson.tsx
@@ -17,6 +17,7 @@ import SokPersonResultat from '@/sider/sokperson/SokPersonResultat';
 import { MagnifyingGlassIcon } from '@navikt/aksel-icons';
 import { isNumeric, removePunctuation } from '@/utils/stringUtil';
 import { parseDateString } from '@/utils/dateUtils';
+import { resolveErrorMessage } from '@/api/errors.ts';
 
 const texts = {
   header: 'Søk etter sykmeldt',
@@ -88,6 +89,7 @@ export default function SokPerson() {
   const {
     mutate,
     data: searchResults,
+    error: searchError,
     isPending,
     isError,
     isSuccess,
@@ -184,7 +186,7 @@ export default function SokPerson() {
             </div>
             {isError && (
               <Alert variant="error" size="small">
-                {texts.error}
+                {resolveErrorMessage(searchError)}
               </Alert>
             )}
           </VStack>


### PR DESCRIPTION
### Hva har blitt lagt til✨🌈

Legger til feilmeldinger på "Min oversikt" og "Enhetens oversikt". Vil vise tilgangsmeldinger samt øvrige feilmeldinger slik det gjøres i `syfomodiaperson`. I denne appen ble feilmeldinger håndtert på litt forskjellige måter. Noen ble vist direkte på stedet man gjorde mutasjon, mens andre benyttet seg av en mer global `useNotifications`-hook som skiller seg fra de andre flatene våre. Siden den var mest brukt og ville tatt mest tid å endre på, bestemte jeg meg for å implementere tilgangsfeilmeldinger med den hooken også.

Mange av kallene våre hadde en sånn her:
```
if (error instanceof ApiErrorException && error.code === 403) {
          throwError(error);
        }
```

Det ser jo veldig bevisst ut, men det førte bare til at hele nettsiden kræsjet om man fikk en `403` :shrug: Så jeg fjernet det bare. Si ifra om det er en god grunn til at det var sånn!


### Screenshots 📸✨

<img width="2140" height="680" alt="image" src="https://github.com/user-attachments/assets/f3311383-0c8c-486a-b31f-c2afea2892c1" />

<img width="2140" height="680" alt="image" src="https://github.com/user-attachments/assets/9940cb62-5c49-4e72-bc56-2ab477245e03" />



Ikke egentlig aktuelt for skrivetilgang, men bildet viser at feilmeldingen viser riktige feil avhengig av respons nå:
<img width="514" height="462" alt="image" src="https://github.com/user-attachments/assets/c3b76f17-d196-4993-afde-3bfd376f1a8b" />