### PR TITLE
Fix/infinite retry

### DIFF
--- a/src/api/errors.ts
+++ b/src/api/errors.ts
@@ -75,3 +75,16 @@ export const isClientError = (error: unknown): boolean =>
   error.error.type !== ErrorType.LOGIN_REQUIRED &&
   !!error.code &&
   error.code.toString().startsWith("4");
+
+/**
+ * Checks whether the given error represents an HTTP 4xx client error response
+ * (status code in the 400-499 range), including 401 and 403.
+ *
+ * Unlike {@link isClientError}, this does not exclude LOGIN_REQUIRED (401), so
+ * it can be used to determine that a request should not be retried.
+ */
+export const is4xxError = (error: unknown): boolean =>
+  error instanceof ApiErrorException &&
+  error.code !== undefined &&
+  error.code >= 400 &&
+  error.code < 500;

--- a/src/context/notification/Notifications.ts
+++ b/src/context/notification/Notifications.ts
@@ -3,6 +3,7 @@ import { AlertProps } from "@navikt/ds-react";
 export type NotificationType =
   | "fetchPersonoversiktFailed"
   | "fetchPersonregisterFailed"
+  | "fetchPersonoversiktTilgangFailed"
   | "fetchVeiledereFailed"
   | "fetchAktivVeilederFailed"
   | "tildelVeilederFailed"
@@ -49,6 +50,12 @@ export const FetchPersonoversiktFailed: Notification = {
   variant: "error",
   message:
     "Vi klarte ikke laste inn personoversikten. Du vil ikke kunne se noen hendelser. Vennligst prøv igjen senere.",
+};
+
+export const FetchPersonoversiktTilgangFailed: Notification = {
+  type: "fetchPersonoversiktTilgangFailed",
+  variant: "error",
+  message: "Du har ikke tilgang til å hente personoversikt.",
 };
 
 export const FetchPersonregisterFailed: Notification = {

--- a/src/data/personoversiktHooks.ts
+++ b/src/data/personoversiktHooks.ts
@@ -6,12 +6,16 @@ import {
 import { get, post } from "@/api/axios";
 import { useAktivEnhet } from "@/context/aktivEnhet/AktivEnhetContext";
 import { useNotifications } from "@/context/notification/NotificationContext";
-import { FetchPersonoversiktFailed } from "@/context/notification/Notifications";
+import {
+  FetchPersonoversiktFailed,
+  FetchPersonoversiktTilgangFailed,
+} from "@/context/notification/Notifications";
 import { minutesToMillis } from "@/utils/timeUtils";
 import { useMemo } from "react";
 import { PERSONOVERSIKT_ROOT } from "@/apiConstants";
 import { SokDTO } from "@/api/types/sokDTO";
 import { useGetFeatureToggles } from "@/data/unleash/unleashQueryHooks";
+import { ApiErrorException } from "@/api/errors.ts";
 
 function filterIsUbehandlet(
   personOversiktStatusList: PersonOversiktStatusDTO[],
@@ -48,10 +52,17 @@ export const useGetPersonstatusQuery = () => {
     enabled: !!aktivEnhet,
     staleTime: minutesToMillis(5),
     meta: {
-      handleError: () => {
-        displayNotification(FetchPersonoversiktFailed);
+      handleError: (error) => {
+        if (error instanceof ApiErrorException && error.code === 403) {
+          displayNotification(FetchPersonoversiktTilgangFailed);
+        } else {
+          displayNotification(FetchPersonoversiktFailed);
+        }
       },
-      handleSuccess: () => clearNotification("fetchPersonoversiktFailed"),
+      handleSuccess: () => {
+        clearNotification("fetchPersonoversiktFailed");
+        clearNotification("fetchPersonoversiktTilgangFailed");
+      },
     },
   });
 

--- a/src/mocks/personoversikt/mockPersonoversikt.ts
+++ b/src/mocks/personoversikt/mockPersonoversikt.ts
@@ -14,7 +14,7 @@ const personoversiktEnhet = (generatedPersons: MockPerson[]) => [
 
 export const mockPersonoversikt = (generatedPersons: MockPerson[]) =>
   http.get(`${PERSONOVERSIKT_ROOT}/enhet/:id`, () =>
-    HttpResponse.json(personoversiktEnhet(generatedPersons), { status: 500 }),
+    HttpResponse.json(personoversiktEnhet(generatedPersons)),
   );
 
 export function mockSokPerson() {

--- a/src/mocks/personoversikt/mockPersonoversikt.ts
+++ b/src/mocks/personoversikt/mockPersonoversikt.ts
@@ -14,7 +14,7 @@ const personoversiktEnhet = (generatedPersons: MockPerson[]) => [
 
 export const mockPersonoversikt = (generatedPersons: MockPerson[]) =>
   http.get(`${PERSONOVERSIKT_ROOT}/enhet/:id`, () =>
-    HttpResponse.json(personoversiktEnhet(generatedPersons)),
+    HttpResponse.json(personoversiktEnhet(generatedPersons), { status: 500 }),
   );
 
 export function mockSokPerson() {

--- a/src/queryClient.ts
+++ b/src/queryClient.ts
@@ -16,7 +16,10 @@ export const MAX_QUERY_RETRIES = 3;
  * will not succeed on a subsequent attempt. Other failures (network errors,
  * 5xx, etc.) are retried up to {@link MAX_QUERY_RETRIES} times.
  */
-export function shouldRetryQuery(failureCount: number, error: unknown): boolean {
+export function shouldRetryQuery(
+  failureCount: number,
+  error: unknown,
+): boolean {
   if (is4xxError(error)) {
     return false;
   }

--- a/src/queryClient.ts
+++ b/src/queryClient.ts
@@ -60,6 +60,7 @@ export const queryClient = new QueryClient({
       gcTime: minutesToMillis(60),
       staleTime: minutesToMillis(30),
       retry: shouldRetryQuery,
+      retryOnMount: false,
     },
   },
 });

--- a/src/queryClient.ts
+++ b/src/queryClient.ts
@@ -60,7 +60,6 @@ export const queryClient = new QueryClient({
       gcTime: minutesToMillis(60),
       staleTime: minutesToMillis(30),
       retry: shouldRetryQuery,
-      retryOnMount: false,
     },
   },
 });

--- a/src/queryClient.ts
+++ b/src/queryClient.ts
@@ -1,6 +1,27 @@
 import { QueryCache, QueryClient } from "@tanstack/react-query";
 import { minutesToMillis } from "@/utils/timeUtils";
+import { is4xxError } from "@/api/errors";
 import "@tanstack/react-query";
+
+/**
+ * Maximum number of automatic retry attempts for a failed query, in addition to
+ * the initial request.
+ */
+export const MAX_QUERY_RETRIES = 3;
+
+/**
+ * Determines whether a failed query should be retried.
+ *
+ * Client errors (HTTP 4xx, including 401 and 403) are never retried since they
+ * will not succeed on a subsequent attempt. Other failures (network errors,
+ * 5xx, etc.) are retried up to {@link MAX_QUERY_RETRIES} times.
+ */
+export function shouldRetryQuery(failureCount: number, error: unknown): boolean {
+  if (is4xxError(error)) {
+    return false;
+  }
+  return failureCount < MAX_QUERY_RETRIES;
+}
 
 interface Meta extends Record<string, unknown> {
   handleError: (error: Error) => void;
@@ -35,7 +56,7 @@ export const queryClient = new QueryClient({
       refetchOnWindowFocus: false,
       gcTime: minutesToMillis(60),
       staleTime: minutesToMillis(30),
-      retry: false,
+      retry: shouldRetryQuery,
     },
   },
 });

--- a/src/sider/oversikt/OversiktContainer.tsx
+++ b/src/sider/oversikt/OversiktContainer.tsx
@@ -42,7 +42,7 @@ export default function OversiktContainer(): ReactElement {
       <div className="flex flex-col mx-8">
         <NavigationBar />
         <NotificationBar />
-        {getPersonstatusQuery.isLoading ? (
+        {getPersonstatusQuery.isLoading && !getPersonstatusQuery.isFetched ? (
           <AppSpinner />
         ) : (
           <Oversikt

--- a/test/query/shouldRetryQuery.test.ts
+++ b/test/query/shouldRetryQuery.test.ts
@@ -1,0 +1,74 @@
+import { describe, expect, it } from "vitest";
+import { MAX_QUERY_RETRIES, shouldRetryQuery } from "@/queryClient";
+import {
+  accessDeniedError,
+  ApiErrorException,
+  conflictError,
+  generalError,
+  loginRequiredError,
+  networkError,
+} from "@/api/errors";
+
+function apiError(code?: number): ApiErrorException {
+  const source = new Error("boom");
+  return new ApiErrorException(generalError(source), code);
+}
+
+describe("shouldRetryQuery", () => {
+  describe("client errors (4xx)", () => {
+    it("does not retry a 401 login required error", () => {
+      const error = new ApiErrorException(
+        loginRequiredError(new Error("unauthorized")),
+        401,
+      );
+
+      expect(shouldRetryQuery(0, error)).toBe(false);
+    });
+
+    it("does not retry a 403 access denied error", () => {
+      const error = new ApiErrorException(
+        accessDeniedError(new Error("forbidden")),
+        403,
+      );
+
+      expect(shouldRetryQuery(0, error)).toBe(false);
+    });
+
+    it("does not retry other 4xx errors such as 409 conflict", () => {
+      const error = new ApiErrorException(
+        conflictError(new Error("conflict")),
+        409,
+      );
+
+      expect(shouldRetryQuery(0, error)).toBe(false);
+    });
+  });
+
+  describe("retryable errors", () => {
+    it("retries 5xx server errors until the cap is reached", () => {
+      const error = apiError(500);
+
+      expect(shouldRetryQuery(0, error)).toBe(true);
+      expect(shouldRetryQuery(MAX_QUERY_RETRIES - 1, error)).toBe(true);
+      expect(shouldRetryQuery(MAX_QUERY_RETRIES, error)).toBe(false);
+    });
+
+    it("retries network errors without a status code", () => {
+      const error = new ApiErrorException(networkError(new Error("offline")));
+
+      expect(shouldRetryQuery(0, error)).toBe(true);
+    });
+
+    it("retries unknown non-ApiErrorException errors", () => {
+      const error = new Error("unexpected");
+
+      expect(shouldRetryQuery(0, error)).toBe(true);
+    });
+
+    it("stops retrying once the failure count reaches the cap", () => {
+      const error = apiError(503);
+
+      expect(shouldRetryQuery(MAX_QUERY_RETRIES, error)).toBe(false);
+    });
+  });
+});


### PR DESCRIPTION
### Hva har blitt lagt til✨🌈

Fiks for evig retry:
> OversiktContainer  unmounts the whole  Oversikt  subtree while  isLoading  is true. On a 403, the personstatus query never has data, so each  retryOnMount  refetch resets its status from     ┃
    error  →  pending , which flips  isLoading / isPending  back to true → spinner → unmount → the subtree re-subscribes → refetch → repeat (~140×/sec, network-gated).

La også til feilmelding for 403 og retry logikk.

### Screenshots 📸✨
<img width="1680" height="678" alt="Skjermbilde 2026-07-01 kl  16 43 00" src="https://github.com/user-attachments/assets/1782891c-cd1b-471d-849a-32ecabf56aa5" />
