### PR TITLE
IS-3582: Select active bruker on list load

### DIFF
--- a/src/components/LinkSyfomodiaperson.tsx
+++ b/src/components/LinkSyfomodiaperson.tsx
@@ -2,7 +2,7 @@ import React, { ReactElement } from "react";
 import { PersonData } from "@/api/types/personregisterTypes";
 import { linkToNewHostAndPath, Subdomain } from "@/utils/miljoUtil";
 import { Labels } from "@/components/Labels";
-import { useAktivBruker } from "@/data/modiacontext/useAktivBruker";
+import { useAktivBrukerMutation } from "@/data/modiacontext/useAktivBrukerMutation";
 import { Link } from "@navikt/ds-react";
 
 export function lenkeTilModia(personData: PersonData): string {
@@ -60,7 +60,7 @@ export function LinkSyfomodiaperson({
   personident,
   linkText,
 }: Props): ReactElement {
-  const aktivBruker = useAktivBruker();
+  const aktivBruker = useAktivBrukerMutation();
   const onPersonClick = () => {
     aktivBruker.mutate(personident, {
       onSuccess: () => {

--- a/src/data/modiacontext/modiacontextQueryHooks.ts
+++ b/src/data/modiacontext/modiacontextQueryHooks.ts
@@ -1,0 +1,19 @@
+import { MODIACONTEXTHOLDER_ROOT } from "@/apiConstants";
+import { get } from "@/api/axios";
+import { AktivBrukerDTO } from "@/data/modiacontext/modiacontextTypes";
+import { useQuery } from "@tanstack/react-query";
+import { minutesToMillis } from "@/utils/timeUtils.ts";
+
+export const modiacontextQueryKeys = {
+  aktivbruker: ["aktivbruker"],
+};
+
+export function useAktivBruker() {
+  const path = `${MODIACONTEXTHOLDER_ROOT}/context/aktivbruker`;
+  const fetchAktivBruker = () => get<AktivBrukerDTO>(path);
+  return useQuery({
+    queryKey: modiacontextQueryKeys.aktivbruker,
+    queryFn: fetchAktivBruker,
+    staleTime: minutesToMillis(60 * 12),
+  });
+}

--- a/src/data/modiacontext/modiacontextTypes.ts
+++ b/src/data/modiacontext/modiacontextTypes.ts
@@ -1,0 +1,8 @@
+export enum EventType {
+  NY_AKTIV_BRUKER = "NY_AKTIV_BRUKER",
+}
+
+export interface AktivBrukerDTO {
+  aktivBruker: string;
+  aktivEnhet: string;
+}

--- a/src/data/modiacontext/useAktivBrukerMutation.ts
+++ b/src/data/modiacontext/useAktivBrukerMutation.ts
@@ -1,14 +1,13 @@
+import { useMutation } from "@tanstack/react-query";
 import { post } from "@/api/axios";
 import { MODIACONTEXTHOLDER_ROOT } from "@/apiConstants";
-import { useMutation } from "@tanstack/react-query";
+import { EventType } from "@/data/modiacontext/modiacontextTypes.ts";
 
-const NY_AKTIV_BRUKER = "NY_AKTIV_BRUKER";
-
-export const useAktivBruker = () =>
+export const useAktivBrukerMutation = () =>
   useMutation({
     mutationFn: (fnr: string) =>
       post(`${MODIACONTEXTHOLDER_ROOT}/context`, {
         verdi: fnr,
-        eventType: NY_AKTIV_BRUKER,
+        eventType: EventType.NY_AKTIV_BRUKER,
       }),
   });

--- a/src/decorator/Decorator.tsx
+++ b/src/decorator/Decorator.tsx
@@ -1,12 +1,12 @@
 import React, { useLayoutEffect, useRef } from "react";
 import { decoratorConfig } from "./decoratorConfig";
 import { linkToNewHostAndPath, Subdomain } from "@/utils/miljoUtil";
-import { useAktivBruker } from "@/data/modiacontext/useAktivBruker";
+import { useAktivBrukerMutation } from "@/data/modiacontext/useAktivBrukerMutation";
 import { useAktivEnhet } from "@/context/aktivEnhet/AktivEnhetContext.tsx";
 
 const Decorator = () => {
   const aktivEnhet = useAktivEnhet();
-  const aktivBruker = useAktivBruker();
+  const aktivBruker = useAktivBrukerMutation();
   const decoratorRef = useRef<InternarbeidsflateDecoratorElement>(null);
 
   useLayoutEffect(() => {

--- a/src/hooks/usePagination.ts
+++ b/src/hooks/usePagination.ts
@@ -1,0 +1,66 @@
+import { useState } from "react";
+
+export const PAGINATED_NUMBER_OF_ITEMS = 50;
+
+export interface Pagination {
+  page: number;
+  setPage: (page: number) => void;
+  numberOfItemsPerPage: number;
+  numberOfPages: number;
+  /** 0-based index of the first visible item. */
+  startItem: number;
+  /** 0-based, exclusive end index of the visible items (e.g. for use with `Array.slice`). */
+  endItem: number;
+  allItemsVisible: boolean;
+  showToggleAllItems: boolean;
+  toggleShowAllItems: () => void;
+}
+
+/**
+ * Owns pagination state (current page and page size) and derives the
+ * visible item range for a list of `numberOfItemsTotal` items. Lives above
+ * both the pagination controls (`PaginationContainer`) and the table so a
+ * parent can also programmatically jump to the page containing a given item.
+ */
+export function usePagination(numberOfItemsTotal: number): Pagination {
+  const [numberOfItemsPerPage, setNumberOfItemsPerPage] = useState(
+    PAGINATED_NUMBER_OF_ITEMS,
+  );
+  const [page, setPage] = useState(1);
+
+  const numberOfPages =
+    numberOfItemsTotal < numberOfItemsPerPage
+      ? 1
+      : Math.ceil(numberOfItemsTotal / numberOfItemsPerPage);
+  const allItemsVisible = numberOfItemsPerPage === numberOfItemsTotal;
+  const showToggleAllItems = numberOfItemsTotal > PAGINATED_NUMBER_OF_ITEMS;
+
+  const startItem = Math.min(
+    (page - 1) * numberOfItemsPerPage,
+    numberOfItemsTotal,
+  );
+  const endItem = allItemsVisible
+    ? numberOfItemsTotal
+    : Math.min(page * numberOfItemsPerPage, numberOfItemsTotal);
+
+  function toggleShowAllItems() {
+    if (allItemsVisible) {
+      setNumberOfItemsPerPage(PAGINATED_NUMBER_OF_ITEMS);
+    } else {
+      setNumberOfItemsPerPage(numberOfItemsTotal);
+      setPage(1);
+    }
+  }
+
+  return {
+    page,
+    setPage,
+    numberOfItemsPerPage,
+    numberOfPages,
+    startItem,
+    endItem,
+    allItemsVisible,
+    showToggleAllItems,
+    toggleShowAllItems,
+  };
+}

--- a/src/mocks/data/aktivBrukerMock.ts
+++ b/src/mocks/data/aktivBrukerMock.ts
@@ -1,0 +1,14 @@
+import { AktivBrukerDTO } from "@/data/modiacontext/modiacontextTypes.ts";
+
+export const ARBEIDSTAKER_DEFAULT = {
+  epost: "korrupt@farligheismontering.no",
+  personIdent: "01999911111",
+  navn: {
+    fornavn: "Korrupt",
+    etternavn: "Heis",
+  },
+};
+
+export const AKTIV_BRUKER_DEFAULT: Partial<AktivBrukerDTO> = {
+  aktivBruker: ARBEIDSTAKER_DEFAULT.personIdent,
+};

--- a/src/mocks/modiacontextholder/mockModiacontextholder.ts
+++ b/src/mocks/modiacontextholder/mockModiacontextholder.ts
@@ -1,5 +1,7 @@
 import { MODIACONTEXTHOLDER_ROOT } from "@/apiConstants";
 import { http, HttpResponse } from "msw";
+import { AKTIV_BRUKER_DEFAULT } from "@/mocks/data/aktivBrukerMock.ts";
+import { aktivEnhetMock } from "@/mocks/data/aktivEnhetMock.ts";
 
 const saksbehandler = {
   ident: "Z999999",
@@ -19,13 +21,13 @@ const saksbehandler = {
 };
 
 const aktivBruker = {
-  aktivBruker: null,
-  aktivEnhet: null,
+  aktivBruker: AKTIV_BRUKER_DEFAULT.aktivBruker,
+  aktivEnhet: AKTIV_BRUKER_DEFAULT.aktivEnhet,
 };
 
 const aktivEnhet = {
-  aktivBruker: null,
-  aktivEnhet: "0316",
+  aktivBruker: aktivEnhetMock.aktivBruker,
+  aktivEnhet: aktivEnhetMock.aktivEnhet,
 };
 
 export const mockModiacontextholder = [

--- a/src/sider/oversikt/sokeresultat/Sokeresultat.tsx
+++ b/src/sider/oversikt/sokeresultat/Sokeresultat.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from "react";
+import React, { useEffect, useRef, useState } from "react";
 import { PersonregisterState } from "@/api/types/personregisterTypes";
 import {
   Filterable,
@@ -18,20 +18,24 @@ import OversiktTable from "@/sider/oversikt/sokeresultat/oversikttable/OversiktT
 import { useSorting } from "@/hooks/useSorting";
 import { useVeiledereQuery } from "@/data/veiledereQueryHooks";
 import EmptyDrawer from "@/sider/oversikt/sokeresultat/oversikttable/EmptyDrawer";
+import { useAktivBruker } from "@/data/modiacontext/modiacontextQueryHooks.ts";
+import AppSpinner from "@/components/AppSpinner.tsx";
+import { usePagination } from "@/hooks/usePagination";
 
 interface Props {
   allEvents: Filterable<PersonregisterState>;
 }
 
 export default function Sokeresultat({ allEvents }: Props) {
+  const aktivBruker = useAktivBruker();
+
   const { filterState } = useFilters();
   const { selectedTab } = useTabType();
   const { sorting, setSorting } = useSorting();
   const veiledereQuery = useVeiledereQuery();
 
   const [selectedPersoner, setSelectedPersoner] = useState<string[]>([]);
-  const [startItem, setStartItem] = useState(0);
-  const [endItem, setEndItem] = useState(0);
+  const hasJumpedToInitialPage = useRef(false);
 
   useEffect(() => {
     setSelectedPersoner([]);
@@ -54,14 +58,10 @@ export default function Sokeresultat({ allEvents }: Props) {
   }
 
   const allFnr = Object.keys(filteredEvents.value);
+  const pagination = usePagination(allFnr.length);
 
   const checkAllHandler = (checked: boolean): void => {
     setSelectedPersoner(checked ? allFnr : []);
-  };
-
-  const onPageChange = (startItem: number, endItem: number): void => {
-    setStartItem(startItem);
-    setEndItem(endItem);
   };
 
   const sortedPersonregister = getSortedEventsFromSortingType(
@@ -69,16 +69,41 @@ export default function Sokeresultat({ allEvents }: Props) {
     veiledereQuery.data || [],
     sorting,
   );
-  const paginatedPersonregister = Object.fromEntries(
-    Object.entries(sortedPersonregister).slice(startItem, endItem + 1),
+  const personListe = Object.entries(sortedPersonregister).slice(
+    pagination.startItem,
+    pagination.endItem,
   );
-  const personListe = Object.entries(paginatedPersonregister);
+
+  useEffect(() => {
+    if (hasJumpedToInitialPage.current || !aktivBruker.isSuccess) {
+      return;
+    }
+
+    const initialActivePersonFnr = aktivBruker.data.aktivBruker;
+    const personIndex = Object.keys(sortedPersonregister).indexOf(
+      initialActivePersonFnr,
+    );
+    if (personIndex === -1) return;
+
+    hasJumpedToInitialPage.current = true;
+    pagination.setPage(
+      Math.floor(personIndex / pagination.numberOfItemsPerPage) + 1,
+    );
+  }, [aktivBruker, sortedPersonregister, pagination]);
+
+  if (!aktivBruker.isSuccess) {
+    return (
+      <div>
+        <AppSpinner />
+      </div>
+    );
+  }
 
   return (
     <div className="flex-[3]">
       <Toolbar
         numberOfItemsTotal={allFnr.length}
-        onPageChange={onPageChange}
+        pagination={pagination}
         isAllSelected={allFnr.length === selectedPersoner.length}
         checkAllHandler={checkAllHandler}
         selectedPersoner={selectedPersoner}
@@ -94,6 +119,7 @@ export default function Sokeresultat({ allEvents }: Props) {
           personListe={personListe}
           selectedRows={selectedPersoner}
           setSelectedRows={setSelectedPersoner}
+          initialActivePersonFnr={aktivBruker.data.aktivBruker}
         />
       )}
     </div>

--- a/src/sider/oversikt/sokeresultat/oversikttable/OversiktTable.tsx
+++ b/src/sider/oversikt/sokeresultat/oversikttable/OversiktTable.tsx
@@ -1,4 +1,4 @@
-import React, { ReactElement } from "react";
+import React, { ReactElement, useEffect, useRef } from "react";
 import { Checkbox, Table } from "@navikt/ds-react";
 import { VeilederColumn } from "@/sider/oversikt/sokeresultat/oversikttable/VeilederColumn";
 import { PersonData } from "@/api/types/personregisterTypes";
@@ -25,6 +25,7 @@ interface Props {
   setSelectedRows: (rows: string[]) => void;
   sorting: Sorting;
   setSorting: (sorting: Sorting) => void;
+  initialActivePersonFnr?: string;
 }
 
 export default function OversiktTable({
@@ -33,9 +34,28 @@ export default function OversiktTable({
   setSelectedRows,
   sorting,
   setSorting,
+  initialActivePersonFnr,
 }: Props): ReactElement {
   const { columns } = useSorting();
   const { selectedTab } = useTabType();
+  const activeRowRef = useRef<HTMLTableRowElement | null>(null);
+  const hasScrolledToActiveRow = useRef(false);
+
+  useEffect(() => {
+    if (
+      hasScrolledToActiveRow.current ||
+      !initialActivePersonFnr ||
+      !activeRowRef.current
+    ) {
+      return;
+    }
+
+    activeRowRef.current.scrollIntoView({
+      behavior: "smooth",
+      block: "center",
+    });
+    hasScrolledToActiveRow.current = true;
+  }, [personListe, initialActivePersonFnr]);
 
   function handleSort(sortKey: string | undefined) {
     let direction: "none" | "ascending" | "descending";
@@ -110,7 +130,13 @@ export default function OversiktTable({
       </Table.Header>
       <Table.Body>
         {personListe.map(([fnr, persondata], index) => (
-          <Table.Row key={index}>
+          <Table.Row
+            key={index}
+            ref={fnr === initialActivePersonFnr ? activeRowRef : undefined}
+            className={
+              fnr === initialActivePersonFnr ? "border-3 border-solid" : ""
+            }
+          >
             <Table.DataCell>
               <Checkbox
                 checked={isRowSelected(fnr)}

--- a/src/sider/oversikt/sokeresultat/toolbar/PaginationContainer.tsx
+++ b/src/sider/oversikt/sokeresultat/toolbar/PaginationContainer.tsx
@@ -1,64 +1,22 @@
-import React, { ReactElement, useEffect, useState } from "react";
+import React, { ReactElement } from "react";
 import { Pagination, Switch } from "@navikt/ds-react";
-
-export const PAGINATED_NUMBER_OF_ITEMS = 50;
+import { Pagination as PaginationState } from "@/hooks/usePagination";
 
 interface PaginationContainerProps {
-  numberOfItemsTotal: number;
-  setPageInfo: (indices: {
-    firstVisibleIndex: number;
-    lastVisibleIndex: number;
-  }) => void;
-  onPageChange: (start: number, end: number) => void;
+  pagination: PaginationState;
 }
 
 const PaginationContainer = ({
-  numberOfItemsTotal,
-  setPageInfo,
-  onPageChange,
+  pagination,
 }: PaginationContainerProps): ReactElement => {
-  const [numberOfItemsPerPage, setNumberOfItemsPerPage] = useState(
-    PAGINATED_NUMBER_OF_ITEMS,
-  );
-  const [page, setPage] = useState(1);
-  const numberOfPages =
-    numberOfItemsTotal < numberOfItemsPerPage
-      ? 1
-      : Math.ceil(numberOfItemsTotal / numberOfItemsPerPage);
-  const allItemsVisible = numberOfItemsPerPage === numberOfItemsTotal;
-  const showToggleAllItems = numberOfItemsTotal > PAGINATED_NUMBER_OF_ITEMS;
-
-  useEffect(() => {
-    const start = Math.min(
-      (page - 1) * numberOfItemsPerPage,
-      numberOfItemsTotal,
-    );
-    const end = allItemsVisible
-      ? numberOfItemsTotal
-      : Math.min(page * numberOfItemsPerPage - 1, numberOfItemsTotal);
-
-    setPageInfo({
-      firstVisibleIndex: start,
-      lastVisibleIndex: end,
-    });
-    onPageChange(start, end);
-  }, [
-    allItemsVisible,
-    numberOfItemsPerPage,
-    numberOfItemsTotal,
-    onPageChange,
+  const {
     page,
-    setPageInfo,
-  ]);
-
-  const handleToggleShowAll = () => {
-    if (allItemsVisible) {
-      setNumberOfItemsPerPage(PAGINATED_NUMBER_OF_ITEMS);
-    } else {
-      setNumberOfItemsPerPage(numberOfItemsTotal);
-      setPage(1);
-    }
-  };
+    setPage,
+    numberOfPages,
+    allItemsVisible,
+    showToggleAllItems,
+    toggleShowAllItems,
+  } = pagination;
 
   return (
     <div className="flex flex-row items-center gap-6">
@@ -72,7 +30,7 @@ const PaginationContainer = ({
         <Switch
           size="small"
           checked={allItemsVisible}
-          onChange={handleToggleShowAll}
+          onChange={toggleShowAllItems}
         >
           Vis alle
         </Switch>

--- a/src/sider/oversikt/sokeresultat/toolbar/TildelOppfolgingsenhet/PaginationLabel.tsx
+++ b/src/sider/oversikt/sokeresultat/toolbar/TildelOppfolgingsenhet/PaginationLabel.tsx
@@ -1,19 +1,19 @@
 import { Label } from "@navikt/ds-react";
 import React from "react";
-import { PageInfoType } from "@/sider/oversikt/sokeresultat/toolbar/Toolbar";
+import { Pagination } from "@/hooks/usePagination";
 
 interface Props {
-  pageInfo: PageInfoType;
+  pagination: Pagination;
   numberOfItemsTotal: number;
   selectedPersoner: string[];
 }
 
 const textPaginatedUsers = (
-  pageInfo: PageInfoType,
+  pagination: Pagination,
   numberOfItemsTotal: number,
 ) => {
-  return `Viser ${pageInfo.firstVisibleIndex + 1}-${
-    pageInfo.lastVisibleIndex
+  return `Viser ${pagination.startItem + 1}-${
+    pagination.endItem
   } av ${numberOfItemsTotal} brukere.`;
 };
 
@@ -22,14 +22,14 @@ const textSelectedPersoner = (amount: number) => {
 };
 
 export default function PaginationLabel({
-  pageInfo,
+  pagination,
   numberOfItemsTotal,
   selectedPersoner,
 }: Props) {
   return (
     <div className="px-1 py-2 flex justify-between items-center">
       <Label size="small">
-        {textPaginatedUsers(pageInfo, numberOfItemsTotal)}
+        {textPaginatedUsers(pagination, numberOfItemsTotal)}
       </Label>
       {selectedPersoner.length > 0 && (
         <Label size="small">

--- a/src/sider/oversikt/sokeresultat/toolbar/Toolbar.tsx
+++ b/src/sider/oversikt/sokeresultat/toolbar/Toolbar.tsx
@@ -2,14 +2,13 @@ import TildelVeileder from "./TildelVeileder";
 import React, { useRef, useState } from "react";
 import styled from "styled-components";
 import themes from "../../../../styles/themes";
-import PaginationContainer, {
-  PAGINATED_NUMBER_OF_ITEMS,
-} from "@/sider/oversikt/sokeresultat/toolbar/PaginationContainer";
+import PaginationContainer from "@/sider/oversikt/sokeresultat/toolbar/PaginationContainer";
 import TildelOppfolgingsenhetModal from "@/sider/oversikt/sokeresultat/toolbar/TildelOppfolgingsenhet/TildelOppfolgingsenhetModal";
 import TildelOppfolgingsenhetButton from "@/sider/oversikt/sokeresultat/toolbar/TildelOppfolgingsenhet/TildelOppfolgingsenhetButton";
 import { useGetFeatureToggles } from "@/data/unleash/unleashQueryHooks";
 import PaginationLabel from "@/sider/oversikt/sokeresultat/toolbar/TildelOppfolgingsenhet/PaginationLabel";
 import { Alert } from "@navikt/ds-react";
+import { Pagination } from "@/hooks/usePagination";
 
 const ToolbarStyled = styled.div`
   display: flex;
@@ -31,23 +30,14 @@ export interface FeedbackNotification {
 export interface Props {
   isAllSelected: boolean;
   numberOfItemsTotal: number;
+  pagination: Pagination;
   checkAllHandler: (checked: boolean) => void;
-  onPageChange: (startItem: number, endItem: number) => void;
   selectedPersoner: string[];
   setSelectedPersoner: (personer: string[]) => void;
 }
 
-export interface PageInfoType {
-  firstVisibleIndex: number;
-  lastVisibleIndex: number;
-}
-
 export default function Toolbar(props: Props) {
   const { toggles } = useGetFeatureToggles();
-  const [pageInfo, setPageInfo] = useState<PageInfoType>({
-    firstVisibleIndex: 0,
-    lastVisibleIndex: PAGINATED_NUMBER_OF_ITEMS,
-  });
   const [tableFeedbackNotification, setTableFeedbackNotification] = useState<
     FeedbackNotification | undefined
   >();
@@ -56,7 +46,7 @@ export default function Toolbar(props: Props) {
   return (
     <>
       <PaginationLabel
-        pageInfo={pageInfo}
+        pagination={props.pagination}
         numberOfItemsTotal={props.numberOfItemsTotal}
         selectedPersoner={props.selectedPersoner}
       />
@@ -83,11 +73,7 @@ export default function Toolbar(props: Props) {
               />
             )}
           </div>
-          <PaginationContainer
-            numberOfItemsTotal={props.numberOfItemsTotal}
-            onPageChange={props.onPageChange}
-            setPageInfo={setPageInfo}
-          />
+          <PaginationContainer pagination={props.pagination} />
         </section>
         {!!tableFeedbackNotification && (
           <Alert

--- a/test/components/Sokeresultat.test.tsx
+++ b/test/components/Sokeresultat.test.tsx
@@ -3,7 +3,10 @@ import Sokeresultat from "@/sider/oversikt/sokeresultat/Sokeresultat";
 import { personregister } from "../data/fellesTestdata";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { Filterable } from "@/utils/hendelseFilteringUtils";
-import { AktivEnhetProvider } from "@/context/aktivEnhet/AktivEnhetContext";
+import {
+  AktivEnhetContext,
+  AktivEnhetProvider,
+} from "@/context/aktivEnhet/AktivEnhetContext";
 import { NotificationProvider } from "@/context/notification/NotificationContext";
 import { stubAktivVeileder } from "../stubs/stubAktivVeileder";
 import { screen } from "@testing-library/react";
@@ -13,6 +16,8 @@ import { FilterState } from "@/context/filters/filterContextState";
 import { testQueryClient } from "../testQueryClient";
 import { renderWithRouter } from "../testRenderUtils";
 import { routes } from "@/routers/routes";
+import { stubModiaContext } from "../stubs/stubModiaContext.ts";
+import { aktivEnhetMock } from "@/mocks/data/aktivEnhetMock.ts";
 
 let queryClient: QueryClient;
 
@@ -20,9 +25,14 @@ const renderSokeresultat = () =>
   renderWithRouter(
     <NotificationProvider>
       <QueryClientProvider client={queryClient}>
-        <AktivEnhetProvider>
+        <AktivEnhetContext.Provider
+          value={{
+            aktivEnhet: aktivEnhetMock.aktivEnhet,
+            handleAktivEnhetChanged: () => void 0,
+          }}
+        >
           <Sokeresultat allEvents={new Filterable(personregister)} />
-        </AktivEnhetProvider>
+        </AktivEnhetContext.Provider>
       </QueryClientProvider>
     </NotificationProvider>,
     routes.ENHET_OVERSIKT,
@@ -32,11 +42,13 @@ describe("Sokeresultat", () => {
   beforeEach(() => {
     queryClient = testQueryClient();
     stubAktivVeileder();
+    stubModiaContext();
   });
 
-  it("Skal inneholde knapperad", () => {
+  it("Skal inneholde knapperad", async () => {
     renderSokeresultat();
-    expect(screen.getByRole("button", { name: "Tildel veileder" })).to.exist;
+    expect(await screen.findByRole("button", { name: "Tildel veileder" })).to
+      .exist;
     const velgAlleCheckbox = screen.getByRole("checkbox", {
       name: "Velg alle",
       checked: false,
@@ -44,13 +56,13 @@ describe("Sokeresultat", () => {
     expect(velgAlleCheckbox).to.exist;
   });
 
-  it("Skal inneholde liste av personer", () => {
+  it("Skal inneholde liste av personer", async () => {
     renderSokeresultat();
-    expect(screen.getByRole("link", { name: "Navn, Et" })).to.exist;
+    expect(await screen.findByRole("link", { name: "Navn, Et" })).to.exist;
     expect(screen.getByRole("link", { name: "Navn, Et Annet" })).to.exist;
   });
 
-  it("Filters søkeresultat by motedatasvar", () => {
+  it("Filters søkeresultat by motedatasvar", async () => {
     const filterSetMotedatasvar: FilterState = {
       tekstFilter: "",
       selectedVeilederIdents: [],
@@ -101,7 +113,7 @@ describe("Sokeresultat", () => {
       </NotificationProvider>,
       routes.ENHET_OVERSIKT,
     );
-    expect(screen.getByRole("link", { name: "Navn, Et" })).to.exist;
+    expect(await screen.findByRole("link", { name: "Navn, Et" })).to.exist;
     expect(screen.queryByRole("link", { name: "Navn, Et Annet" })).to.not.exist;
   });
 });

--- a/test/containers/OversiktContainer.test.tsx
+++ b/test/containers/OversiktContainer.test.tsx
@@ -8,6 +8,9 @@ import { stubPersonregister } from "../stubs/stubPersonregister";
 import { stubAktivVeileder } from "../stubs/stubAktivVeileder";
 import { stubModiaContext } from "../stubs/stubModiaContext";
 import { stubVeiledere } from "../stubs/stubVeiledere";
+import { stubTildelOppfolgingsenhet } from "../stubs/stubTildelOppfolgingsenhet";
+import { mockEreg } from "@/mocks/ereg/mockEreg";
+import { mockServer } from "../setup";
 import { aktivEnhetMock } from "@/mocks/data/aktivEnhetMock";
 import { FilterProvider } from "@/context/filters/FilterContext";
 import {
@@ -52,6 +55,9 @@ function renderOversikten(notifications: Notification[] = []) {
 describe("OversiktContainer", () => {
   beforeEach(() => {
     queryClient = getQueryClientWithMockdata();
+    stubModiaContext();
+    stubTildelOppfolgingsenhet();
+    mockServer.use(mockEreg);
   });
 
   afterEach(() => {

--- a/test/setup.ts
+++ b/test/setup.ts
@@ -1,9 +1,11 @@
-import { afterAll, afterEach, beforeAll } from "vitest";
+import { afterAll, afterEach, beforeAll, vi } from "vitest";
 import { setupServer } from "msw/node";
 import { mockUnleash } from "@/mocks/mockUnleash";
 import { mockSyfoveileder } from "@/mocks/syfoveileder/mockSyfoveileder";
 
 export const mockServer = setupServer(mockUnleash, ...mockSyfoveileder);
+
+Element.prototype.scrollIntoView = vi.fn();
 
 // Start server before all tests
 beforeAll(() => mockServer.listen({ onUnhandledRequest: "warn" }));

--- a/test/stubs/stubModiaContext.ts
+++ b/test/stubs/stubModiaContext.ts
@@ -2,9 +2,11 @@ import { MODIACONTEXTHOLDER_ROOT } from "@/apiConstants";
 import { aktivEnhetMock } from "@/mocks/data/aktivEnhetMock";
 import { mockServer } from "../setup";
 import { http, HttpResponse } from "msw";
+import { mockModiacontextholder } from "@/mocks/modiacontextholder/mockModiacontextholder.ts";
 
 export const stubModiaContext = () => {
   mockServer.use(
+    ...mockModiacontextholder,
     http.get(`*${MODIACONTEXTHOLDER_ROOT}/context/aktivenhet`, () =>
       HttpResponse.json(aktivEnhetMock),
     ),


### PR DESCRIPTION
Denne PRen legger til at oversikten hopper til den siden/raden og markerer brukeren veileder har valgt i sin context. Det største problemet var at `PaginationContainer` og `Sokeresultat` tok ansvar for hver sin del av paginering. Dette gjorde at det ikke var mulig å finne ut av hvilken side et element i en gitt liste faktisk lå og man kunne heller ikke programmatisk velge en side, siden dette måtte gjøres via knappetrykkl på pagineringskomponenten.

Løsningen ble å trekke ut de to logikkdelene og flytte det over til en felles `usePagination`. Denne funksjonen er egentlig ganske lik som det har vært tidligere, med noen ekstra props. I tillegg har `Sokeresultat` nå logikk som ved sidelast velger å hoppe til personen man har i context.

PRen fikser også en bug hvor en label som viste "Viser x-y" viste feil tall på y.

**Så er det spørsmål til publikum:** Vil vi ha det slik at oversikten _alltid_ hopper til valgt bruker ved refresh? Modia personoversikt har gjort det slik at man har en tilbakeknapp som man trykker på, og den vil sende deg til personen man har valgt. Men det fører til at refresh og tilbaketrykk i browser ikke fungerer. Personlig foretrekker jeg det som jeg lagde det nå, men kom gjerne med noen tanker om dette hvis jeg har oversett noe.

- [x] Testet i dev (dog fant jeg ingen kontorer med flere enn 50 brukere slik at paginering slo inn)