### PR TITLE
IS: Update mocks for umami

### DIFF
--- a/src/mocks/handlers.ts
+++ b/src/mocks/handlers.ts
@@ -1,4 +1,4 @@
-import { HttpHandler, WebSocketHandler, ws } from "msw";
+import { HttpHandler, WebSocketHandler } from "msw";
 import { generatePersons } from "./mockUtils";
 import { mockUnleash } from "@/mocks/mockUnleash";
 import { mockSyfoveileder } from "@/mocks/syfoveileder/mockSyfoveileder";
@@ -20,9 +20,6 @@ import { mockUmami } from "@/mocks/umami/mockUmami";
 const generatedPersons = generatePersons(50);
 
 const handlers: Array<HttpHandler | WebSocketHandler> = [
-  ws.link("ws://localhost:4000/*").addEventListener("connection", () => {
-    // Silently ignore WebSocket connections to Internflatedecorator in local development
-  }),
   mockFlexjar,
   mockUmami,
   mockUnleash,

--- a/src/mocks/modiacontextholder/mockModiacontextholder.ts
+++ b/src/mocks/modiacontextholder/mockModiacontextholder.ts
@@ -1,5 +1,5 @@
 import { MODIACONTEXTHOLDER_ROOT } from "@/apiConstants";
-import { http, HttpResponse } from "msw";
+import { http, HttpResponse, ws } from "msw";
 
 const saksbehandler = {
   ident: "Z999999",
@@ -49,4 +49,7 @@ export const mockModiacontextholder = [
     `${MODIACONTEXTHOLDER_ROOT}/context`,
     () => new HttpResponse(null, { status: 204 }),
   ),
+  ws.link("ws://localhost:4000/*").addEventListener("connection", () => {
+    // Silently ignore WebSocket connections to Internflatedecorator in local development
+  }),
 ];

--- a/src/mocks/umami/mockUmami.ts
+++ b/src/mocks/umami/mockUmami.ts
@@ -1,5 +1,8 @@
 import { http, HttpResponse } from "msw";
 
-export const mockUmami = http.post("https://umami.nav.no/api/send", () => {
-  return HttpResponse.text("mocked umami");
-});
+export const mockUmami = http.post(
+  "https://reops-event-proxy.ekstern.dev.nav.no/api/send",
+  () => {
+    return HttpResponse.text("mocked umami");
+  },
+);


### PR DESCRIPTION
### Hva har blitt lagt til✨🌈
Bare noen forbedringer jeg oppdaget ved forrige PR:

- Bruker riktig url for umami-events, slik at disse ikke sendes lokalt (samme som i syfomodiaperson)
- Flytter websocket-mocken for contextholderen sammen med resten av contextholder-mocks

<img width="482" height="154" alt="image" src="https://github.com/user-attachments/assets/bdd97993-08aa-44c5-976f-21fc6ce3322e" />
