### PR TITLE
IS: Ignore env-variables in tests

### DIFF
--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,10 +1,12 @@
 import { defineConfig } from "vitest/config";
 import svgr from "vite-plugin-svgr";
+import path from "path";
 
 export default defineConfig({
   resolve: {
     tsconfigPaths: true,
   },
+  envDir: path.resolve(__dirname, "test"),
   plugins: [svgr({ include: "**/*.svg" })],
   test: {
     globals: true,


### PR DESCRIPTION
Når man kjører copilot fra sandbox-miljø, kan man ikke kjøre testene fordi den ikke får lov til å lese .env-filen vi har i repoet. env-filene som ligger lokalt er jo bare dummy-data uansett, og vi trenger de heller ikke for å kjøre testene. Derfor sier vi eksplisitt at env-variabler vil finnes i test-mappa, men der vil den ikke finne noe, og vi kan dermed kjøre tester med agenter. Jeg tenker det er nyttig for at agenter kan få feedback-loop på sine egne endringer uten at vi må manuelt kjøre testene og paste inn eventuelle feilmeldinger.
